### PR TITLE
Bumped Update Header Text to current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ gcode:
     BASE_RESUME
 ```
 
-## Update Mainsail to V0.0.11
+## Update Mainsail to V0.0.12
 ```
 sudo service klipper stop
 cd ~/klipper


### PR DESCRIPTION
Your terminal commands are for the latest update V0.0.12, but the header text still said V0.0.11 🙂

Idk why it says I replaced the last line... it didn't change 😕 

Btw, this is amazing work! 👏