### PR TITLE
Renaming kwc to mainsail

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but kwc doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>We're sorry but mainsail doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -13,7 +13,7 @@ export default {
         .then(res => res.json()).then(file => {
             store.commit('setSettings', file);
         }).catch(function() {
-            window.console.warn('No kwc config file found.');
+            window.console.warn('No mainsail config file found.');
         });
 
         Vue.prototype.$socket.sendObj('get_printer_info', {}, 'getKlipperInfo');


### PR DESCRIPTION
Note: package-lock.json still has kwc in the name. I didn't change due to it being build-related