### PR TITLE
Machine Limits Typo

### DIFF
--- a/src/components/panels/Settings/LimitsPanel.vue
+++ b/src/components/panels/Settings/LimitsPanel.vue
@@ -3,7 +3,7 @@
         <v-list-item>
             <v-list-item-avatar color="grey"><v-icon dark>mdi-exclamation-thick</v-icon></v-list-item-avatar>
             <v-list-item-content>
-                <v-list-item-title class="headline">Machinelimits</v-list-item-title>
+                <v-list-item-title class="headline">Machine Limits</v-list-item-title>
             </v-list-item-content>
         </v-list-item>
         <v-divider class="my-2"></v-divider>


### PR DESCRIPTION
Current headline is written as Machinelimits

![image](https://user-images.githubusercontent.com/26986716/82838030-801bb480-9e90-11ea-837d-2846f4459d65.png)

Changed to Machine Limits