### PR TITLE
bugfix: remove M120/M121 from extrude/retract command

### DIFF
--- a/src/components/panels/ExtruderPanel.vue
+++ b/src/components/panels/ExtruderPanel.vue
@@ -72,13 +72,13 @@
                 this.feedrate = value;
             },
             sendRetract() {
-                let gcode = "M120\nM83\nG1 E-"+this.feedAmount+" F"+(this.feedrate * 60)+"\nM121";
+                let gcode = "M83\nG1 E-"+this.feedAmount+" F"+(this.feedrate * 60);
                 this.$store.commit('setLoading', { name: 'extruderRetract' });
                 this.$store.commit('addGcodeResponse', gcode);
                 Vue.prototype.$socket.sendObj('post_printer_gcode_script', { script: gcode }, "respondeExtruderRetract");
             },
             sendDetract() {
-                let gcode = "M120\nM83\nG1 E"+this.feedAmount+" F"+(this.feedrate * 60)+"\nM121";
+                let gcode = "M83\nG1 E"+this.feedAmount+" F"+(this.feedrate * 60);
                 this.$store.commit('setLoading', { name: 'extruderDetract' });
                 this.$store.commit('addGcodeResponse', gcode);
                 Vue.prototype.$socket.sendObj('post_printer_gcode_script', { script: gcode }, "respondeExtruderDetract");


### PR DESCRIPTION
Removes the unnecessary M120 and M121 g-codes when sending an extrude or retract command via the Extrude/Retract button via the Dashboard, which would lead to an "unknown command" error message in the Mainsail console.