### PR TITLE
Use encodeURI for paths

### DIFF
--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -403,7 +403,7 @@
                 let filename = (this.currentPath+"/"+this.contextMenu.item.filename);
                 let link = document.createElement("a");
                 link.download = name;
-                link.href = 'http://' + this.hostname + ':' + this.port + '/server/files/' + encodeURIComponent(filename);
+                link.href = 'http://' + this.hostname + ':' + this.port + '/server/files/' + encodeURI(filename);
                 document.body.appendChild(link);
                 link.click();
                 document.body.removeChild(link);
@@ -435,7 +435,7 @@
             removeFile() {
                 let filename = (this.currentPath+"/"+this.contextMenu.item.filename);
                 axios.delete(
-                    'http://'+ this.hostname + ':' + this.port +'/server/files/'+encodeURIComponent(filename)
+                    'http://'+ this.hostname + ':' + this.port +'/server/files/' + encodeURI(filename)
                 ).then((result) => {
                     this.$toast.success(result.data.result+" successfully deleted.");
                 }).catch(() => {


### PR DESCRIPTION
Moonraker expects file paths to use un-escaped file paths,
 such as gcodes/some%20file.gcode, but encodeURIComponent
 will always escape the slash. Using encodeURI here will not.