### PR TITLE
feature: allows flipping the webcam horizontally and vertically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+.DS_Store
+design
+*.log
+packages/test
+dist
+temp
+.vuerc
+.version
+.versions
+.changelog
+package-lock.json

--- a/src/components/panels/Settings/WebcamPanel.vue
+++ b/src/components/panels/Settings/WebcamPanel.vue
@@ -1,7 +1,5 @@
 <style>
-    .webcamImage {
-        width: 100%;
-    }
+    .content { overflow: hidden; }
 </style>
 
 <template>
@@ -13,18 +11,27 @@
             </v-list-item-content>
         </v-list-item>
         <v-divider class="my-2"></v-divider>
-        <v-card-text class="px-0 pb-0 pt-3 content">
+        <v-card-text class="px-0 pt-3 content">
             <v-row>
                 <v-col class="px-10 py-0">
                     <v-text-field
                         v-model="webcamUrl"
+                        hide-details
                         label="Webcam URL"
                     ></v-text-field>
-                </v-col>
-            </v-row>
-            <v-row>
-                <v-col class="px-10 py-0">
-                    <v-switch v-model="boolNavi" label="Show in Navigation"></v-switch>
+
+                    <v-row v-if="rotationEnabled">
+                        <v-col sm="auto">
+                            <v-switch v-model="rotate" hide-details label="Rotate"></v-switch>
+                        </v-col>
+                        <v-col>
+                            <v-select :items="[{ text: '90 degrees', value: 90 }, { text: '270 degrees', value: 270 }]" v-model="rotateDegrees" hide-details></v-select>
+                        </v-col>
+                    </v-row>
+                    
+                    <v-switch v-model="flipX" hide-details label="Flip webcam horizontally"></v-switch>
+                    <v-switch v-model="flipY" hide-details label="Flip webcam vertically"></v-switch>
+                    <v-switch v-model="boolNavi" hide-details label="Show in navigation"></v-switch>
                 </v-col>
             </v-row>
         </v-card-text>
@@ -38,24 +45,56 @@
         },
         data: function() {
             return {
-
+                rotationEnabled: false
             }
         },
         computed: {
             webcamUrl: {
                 get() {
-                    return this.$store.state.webcam.url;
+                    return this.$store.state.gui.webcam.url;
                 },
-                set(newWebcamUrl) {
-                    return this.$store.dispatch('setSettings', { webcam: { url: newWebcamUrl } });
+                set(url) {
+                    return this.$store.dispatch('setSettings', { gui: { webcam: { url } } });
+                }
+            },
+            flipX: {
+                get() {
+                    return this.$store.state.gui.webcam.flipX;
+                },
+                set(flipX) {
+                    return this.$store.dispatch('setSettings', { gui: { webcam: { flipX } } });
+                }
+            },
+            flipY: {
+                get() {
+                    return this.$store.state.gui.webcam.flipY;
+                },
+                set(flipY) {
+                    return this.$store.dispatch('setSettings', { gui: { webcam: { flipY } } });
+                }
+            },
+            rotate: {
+                get() {
+                    return this.$store.state.gui.webcam.rotate;
+                },
+                set(rotate) {
+                    return this.$store.dispatch('setSettings', { gui: { webcam: { rotate } } });
+                }
+            },
+            rotateDegrees: {
+                get() {
+                    return this.$store.state.gui.webcam.rotateDegrees;
+                },
+                set(rotateDegrees) {
+                    return this.$store.dispatch('setSettings', { gui: { webcam: { rotateDegrees } } });
                 }
             },
             boolNavi: {
                 get() {
                     return this.$store.state.gui.webcam.bool;
                 },
-                set(bool) {
-                    return this.$store.dispatch('setSettings', { gui: { webcam: { bool: bool } } });
+                set(showNav) {
+                    return this.$store.dispatch('setSettings', { gui: { webcam: { bool: showNav } } });
                 }
             },
         },

--- a/src/components/panels/WebcamPanel.vue
+++ b/src/components/panels/WebcamPanel.vue
@@ -14,7 +14,7 @@
         </v-list-item>
         <v-divider class="my-2"></v-divider>
         <v-card-text class="px-0 py-0 content">
-            <img :src="webcamUrl" class="webcamImage" />
+            <img :src="webcamConfig.url" class="webcamImage" :style="webcamStyle" />
         </v-card-text>
     </v-card>
 </template>
@@ -26,18 +26,28 @@
         components: {
 
         },
-        data: function() {
-            return {
-
-            }
-        },
         computed: {
             ...mapState({
-                webcamUrl: state => state.webcam.url,
-            })
+                'webcamConfig': state => state.gui.webcam
+            }),
+            webcamStyle() {
+                var transforms = '';
+                if (this.webcamConfig.flipX) {
+                    transforms += ' scaleX(-1)'
+                }
+                if (this.webcamConfig.flipY) {
+                    transforms += ' scaleY(-1)'
+                }
+                if (this.webcamConfig.rotate && this.webcamConfig.rotateDegrees) {
+                    transforms += ` rotate(${this.webcamConfig.rotateDegrees}deg)`
+                }
+                if (transforms.trimLeft().length) {
+                    return {
+                        transform: transforms.trimLeft(),
+                    }
+                }
+                return '';
+            }
         },
-        methods: {
-
-        }
     }
 </script>

--- a/src/pages/Webcam.vue
+++ b/src/pages/Webcam.vue
@@ -12,8 +12,6 @@
     </div>
 </template>
 <script>
-    import { mapState } from 'vuex';
-
     export default {
         data () {
             return {
@@ -21,9 +19,7 @@
             }
         },
         computed: {
-            ...mapState({
-                webcamUrl: state => state.webcam.url,
-            }),
+
         },
         methods: {
 

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -255,7 +255,7 @@ export default {
     },
 
     showDashboardWebcam: state => {
-        return (state.webcam.url !== "" && state.gui.dashboard.boolWebcam);
+        return (state.gui.webcam.url !== "" && state.gui.dashboard.boolWebcam);
     },
 
     getCurrentExtruder: state => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -24,9 +24,6 @@ export default new Vuex.Store({
             loadingSaveGuiConfig: false,
             loadingEndstopStatus: false,
         },
-        webcam: {
-            url: ""
-        },
         gui: {
             general: {
                 printername: "",
@@ -39,6 +36,11 @@ export default new Vuex.Store({
                 hiddenTempChart: [],
             },
             webcam: {
+                url: "",
+                rotate: false,
+                rotateDegrees: 90,
+                flipX: false,
+                flipY: false,
                 bool: false,
             },
             gcodefiles: {


### PR DESCRIPTION
- Adds settings to toggle a flip on the X or Y axis of the webcam image.
- Updates the webcam view to apply the above two transforms based on the settings.
- Updates default config to represent both toggles off.
- Moves the webcam URL to the same location as other webcam configuration.
- Added a base `.gitignore` to avoid accidental commits to things like `node_modules`.

@meteyou I wasn't sure what your intent was with the webcam URL, so I moved it to be consistent. Happy to move this back if you feel that's appropriate tho.

Also - I've left the settings in place to allow rotation of the webcam feed, but have hidden the controls for now. Allowing rotation on an image that is not square causes issues, as rotation happens after page layout. I researched a bunch of ways to reposition layout based on the transform - but nothing really appealed to me. IMO - it might be better to not allow rotation at all unless we want to implement a more complex solution to this. I tend to think that if a user needs a 90 or 270 degree rotation, it should be done further upstream.