### PR TITLE
Disable browser autocomplete in console

### DIFF
--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -35,6 +35,7 @@
                         solo
                         class="gcode-command-field"
                         ref="gcodeCommandField"
+                        autocomplete="off"
                         v-on:keyup.enter="doSend"
                         v-on:keyup.up="onKeyUp"
                         v-on:keyup.down="onKeyDown"


### PR DESCRIPTION
This stops chrome from breaking the cnonsole history feature