### PR TITLE
Enhancement: Add enabling Gzip for mainsail nginx config

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,6 +148,17 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
+    gzip on;
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_comp_level 4;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/json application/xml;
+
+
     access_log /var/log/nginx/mainsail-access.log;
     error_log /var/log/nginx/mainsail-error.log;
 


### PR DESCRIPTION
Old Pull Request: https://github.com/meteyou/mainsail/pull/78

Revised to place config in `/etc/nginx/sites-available/mainsail`

Also modified `gzip_comp_level` to a value of `4` instead of the default `6` to lower CPU usage... it _may_ now work on the PI Zero without killing the CPU, but I don't have one to test with.