### PR TITLE
Filter console messages before adding them to internally

### DIFF
--- a/src/components/panels/Settings/ConsolePanel.vue
+++ b/src/components/panels/Settings/ConsolePanel.vue
@@ -1,0 +1,59 @@
+<style>
+</style>
+
+<template>
+    <v-card>
+        <v-list-item>
+            <v-list-item-avatar color="grey"><v-icon dark>mdi-console-line</v-icon></v-list-item-avatar>
+            <v-list-item-content>
+                <v-list-item-title class="headline">Console</v-list-item-title>
+            </v-list-item-content>
+        </v-list-item>
+        <v-divider class="my-2"></v-divider>
+        <v-card-text class="px-0 pb-0 pt-3 content">
+            <v-row>
+                <v-col class="px-10 py-0">
+                    <v-textarea
+                        outlined
+                        name="input-7-4"
+                        label="Filters"
+                        v-model="filters"
+                        @blur="updateFilters($event)"
+                    ></v-textarea>
+                </v-col>
+            </v-row>
+        </v-card-text>
+    </v-card>
+</template>
+
+<script>
+    export default {
+        components: {
+
+        },
+        data: function() {
+            return {
+
+            }
+        },
+        computed: {
+            filters: {
+                get() {
+                    let c = this.$store.state.gui.console || {};
+                    return (c.filters || []).join('\n');
+                },
+                set() {
+                }
+            },
+        },
+        methods: {
+            updateFilters($event) {
+
+                let inputValue = $event.currentTarget.value.trim();
+                let filters = [...new Set(inputValue.split('\n'))];
+
+                return this.$store.dispatch('setSettings', { gui: { console: { filters: filters } } });
+            }
+        }
+    }
+</script>

--- a/src/components/panels/Settings/ConsolePanel.vue
+++ b/src/components/panels/Settings/ConsolePanel.vue
@@ -18,6 +18,9 @@
                         name="input-7-4"
                         label="Filters"
                         v-model="filters"
+                        validate-on-blur
+                        :error-messages="filterErrors"
+                        :error-count="filterErrors.length"
                         @blur="updateFilters($event)"
                     ></v-textarea>
                 </v-col>
@@ -27,13 +30,35 @@
 </template>
 
 <script>
+
+    function getFiltersFromText(text) {
+        let inputValue = text.trim();
+        let filters = [...new Set(inputValue.split('\n'))];
+        return filters;
+    }
+
+    function getFilterErrors(filters) {
+
+        let errors = [];
+        filters.forEach(filter => {
+            try { new RegExp(filter); }
+            catch { errors.push(filter); }
+        });
+
+        if (errors.length) {
+            errors.splice(0, 0, 'Invalid filters:');
+        }
+
+        return errors;
+    }
+
     export default {
         components: {
 
         },
         data: function() {
             return {
-
+                filterErrors: []
             }
         },
         computed: {
@@ -44,15 +69,17 @@
                 },
                 set() {
                 }
-            },
+            }
         },
         methods: {
             updateFilters($event) {
 
-                let inputValue = $event.currentTarget.value.trim();
-                let filters = [...new Set(inputValue.split('\n'))];
+                let filters = getFiltersFromText($event.currentTarget.value);
+                this.filterErrors = getFilterErrors(filters);
 
-                return this.$store.dispatch('setSettings', { gui: { console: { filters: filters } } });
+                if (this.filterErrors.length === 0) {
+                    this.$store.dispatch('setSettings', { gui: { console: { filters: filters } } });
+                }
             }
         }
     }

--- a/src/components/panels/Settings/index.js
+++ b/src/components/panels/Settings/index.js
@@ -9,6 +9,7 @@ import LimitsPanel from "./LimitsPanel";
 import ConfigFilesPanel from "./ConfigFilesPanel";
 import RunoutPanel from "./RunoutPanel";
 import SystemPanel from "./SystemPanel";
+import ConsolePanel from "./ConsolePanel";
 
 Vue.component('settings-general-panel', GeneralPanel);
 Vue.component('settings-webcam-panel', WebcamPanel);
@@ -19,6 +20,7 @@ Vue.component('settings-limits-panel', LimitsPanel);
 Vue.component('settings-runout-panel', RunoutPanel);
 Vue.component('settings-system-panel', SystemPanel);
 Vue.component('settings-config-files-panel', ConfigFilesPanel);
+Vue.component('settings-console-panel', ConsolePanel);
 
 export default {
 

--- a/src/pages/settings/interface.vue
+++ b/src/pages/settings/interface.vue
@@ -7,6 +7,7 @@
             </v-col>
             <v-col class="col-12 col-md-6 col-lg-4">
                 <settings-dashboard-panel></settings-dashboard-panel>
+                <settings-console-panel class="mt-6"></settings-console-panel>
             </v-col>
             <v-col class="col-12 col-md-6 col-lg-4">
                 <settings-macros-panel></settings-macros-panel>

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -81,7 +81,6 @@ export default {
     initServer() {
         Vue.prototype.$socket.sendObj('server.files.get_directory', { path: '/config' }, 'getDirectoryRoot');
         Vue.prototype.$socket.sendObj('server.info', {}, 'getServerInfo');
-        Vue.prototype.$socket.sendObj('server.gcode_store', {}, 'getGcodeStore');
     },
 
     initPrinter() {
@@ -93,11 +92,18 @@ export default {
     },
 
     getDirectoryRoot({ commit }, data) {
+        let getGcodeStore = () => {
+            Vue.prototype.$socket.sendObj('server.gcode_store', {}, 'getGcodeStore');
+        };
         if (data.files && data.files.filter((file) => file.filename === "gui.json").length) {
             fetch('//'+store.state.socket.hostname+':'+store.state.socket.port+'/server/files/config/gui.json?time='+Date.now())
                 .then(res => res.json()).then(file => {
-                commit('setSettings', file);
-            });
+                    commit('setSettings', file);
+                })
+                .then(getGcodeStore);
+        }
+        else {
+            getGcodeStore();
         }
     },
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -52,6 +52,10 @@ export default new Vuex.Store({
                 configfiles: {
                     countPerPage: 10,
                 }
+            },
+            console: {
+                filters: [
+                ]
             }
         },
         loadings: [],


### PR DESCRIPTION
Add the ability to apply one or more regular expressions to messages to filter out those we do not want to see. It would be nice to have some way to tell klipper/moonraker not to send these to us in the first place, however, different subscribers may want different filters applied and that could get ugly. 

If that ability is added in the api in the future, this can be removed or tweaked to tell the api what to deliver.

https://github.com/meteyou/mainsail/issues/51

![image](https://user-images.githubusercontent.com/7727467/97118483-10785280-16d8-11eb-8b57-4045ca3fc46f.png)

Simple temperature filter:
`^(?:ok\s+)?(B|C|T\d*):`

I'm still green with vue and vuetify. Inside ConsolePanel.vue, if I did not use blur, it would update $store with every keypress. Since the expressions are cached when evaluated, I didn't want a race between messages coming in and compiling partial regular expressions.

Thinking about it, probably need a way to validate the filters are valid regular expressions, or in the filterMessage method, handle those that don't compile? This may need to be resolved before merging. It works how it is, but only the happy path.