### PR TITLE
clear fileupload after uploading

### DIFF
--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -319,7 +319,10 @@
         methods: {
             uploadFile: function() {
                 if (this.$refs.fileUpload.files.length) {
-                    this.doUploadFile(this.$refs.fileUpload.files[0]);
+                    this.doUploadFile(this.$refs.fileUpload.files[0]).finally(() => {
+                        this.$refs.fileUpload.value = '';
+                    });
+
                 }
             },
             doUploadFile: function(file) {
@@ -330,7 +333,7 @@
                 formData.append('file', file, (this.currentPath+"/"+filename).substring(7));
                 this.$store.commit('setLoading', { name: 'loadingGcodeUpload' });
 
-                axios.post('//' + this.hostname + ':' + this.port + '/server/files/upload',
+                return axios.post('//' + this.hostname + ':' + this.port + '/server/files/upload',
                     formData, {
                         headers: { 'Content-Type': 'multipart/form-data' }
                     }


### PR DESCRIPTION
If you upload a file, then delete it, and then upload the same one with the upload button, it will not upload it. This is because it has the same name and the input type="file" does not trigger a change.

This might not be a problem across all browsers and for those that have this problem, this might not fix them all. This way is the "easy" workaround. The other way is to either completely replace the DOM element, or wrap it inside a form and "reset" that form. If this continues to be an issue, we can investigate those other methods.

This *may* resolve:
https://github.com/meteyou/mainsail/issues/90
