### PR TITLE
Drop update rate on progress circle for significantly less CPU utilization

### DIFF
--- a/src/components/panels/StatusPanel.vue
+++ b/src/components/panels/StatusPanel.vue
@@ -71,7 +71,7 @@
                         :rotate="-90"
                         :size="50"
                         :width="7"
-                        :value="printPercent * 100"
+                        :value="Math.round(printPercent * 100)"
                         color="red"
                     >
                     </v-progress-circular>


### PR DESCRIPTION
I was doing some digging to see if I could drop the CPU utilization of Mainsail some, and I spotted (I think in one of the Vue inspector panes) that the result of the percentage the circular progress bar winds up calculating to some _extremely_ precise number, which causes the progress circle to refresh... well, a _lot_:

https://user-images.githubusercontent.com/2745/105616300-91a8b980-5d9b-11eb-8e91-c80ba4ecc4b3.mov

I changed it to round to whatever the closest percentage is, and it's _much_ more calm:

https://user-images.githubusercontent.com/2745/105616463-ab96cc00-5d9c-11eb-8ac2-0096f5cd5cc8.mov

Anecdotally, doing so seems to drop the CPU utilization by about 10-20%, depending on the browser 🎉 