### PR TITLE
hotfix: mainsail docs logo

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,7 @@
 title: "Mainsail"
 tagline: A web interface for Klipper
 description: Mainsail is a lightweight & responsive web interface for the Klipper 3D printer firmware. It communicates with Moonraker (Klipper-API) from Arksine.
+logo: "/assets/img/logo-mainsail.png"
 theme: just-the-docs
 remote_theme: pmarsceill/just-the-docs
 color_scheme: "mainsail"


### PR DESCRIPTION
I accidentally removed the logo from the config during the recent commit.