### PR TITLE
MJPEG-Streamer Adaptive FPS / Frame Skipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "vue-context": "^6.0.0",
     "vue-github-api": "^0.1.7",
     "vue-headful": "^2.1.0",
+    "vue-observe-visibility": "^1.0.0",
     "vue-plotly": "^1.1.0",
     "vue-prism-editor": "^1.2.2",
     "vue-resource": "^1.5.1",

--- a/src/components/panels/Settings/WebcamPanel.vue
+++ b/src/components/panels/Settings/WebcamPanel.vue
@@ -45,9 +45,14 @@
                 </v-row>
                 <v-row>
                     <v-col class="py-2">
-                        <v-switch v-model="boolWebsocket" hide-details label="Use Websocket Method" class="mt-0"></v-switch>
+                        <v-switch v-model="adaptiveFps" hide-details label="(Experimental) Adaptive FPS" class="mt-0"></v-switch>
                     </v-col>
                 </v-row>
+                <v-row v-if="adaptiveFps">
+                    <v-col class="py-2">
+                        <v-text-field v-model="targetFps" hide-details label="Target FPS" class="mt-0"></v-text-field>
+                    </v-col>
+                </v-row> 
             </v-container>
         </v-card-text>
     </v-card>
@@ -69,6 +74,8 @@
                     return this.$store.state.gui.webcam.url;
                 },
                 set(url) {
+                    if(this.$store.state.gui.webcam.adaptiveFps)
+                        url = url.replace("action=stream", "action=snapshot");
                     return this.$store.dispatch('gui/setSettings', { webcam: { url } });
                 }
             },
@@ -112,14 +119,22 @@
                     return this.$store.dispatch('gui/setSettings', { webcam: { bool: showNav } });
                 }
             },
-            boolWebsocket: {
+            adaptiveFps: {
                 get() {
-                    return this.$store.state.gui.webcam.boolWebsocket;
+                    return this.$store.state.gui.webcam.adaptiveFps;
                 },
-                set(useWebsocket) {
-                    return this.$store.dispatch('gui/setSettings', { webcam: { boolWebsocket: useWebsocket } });
+                set(useAdaptiveFps) {
+                    return this.$store.dispatch('gui/setSettings', { webcam: { adaptiveFps: useAdaptiveFps } });
                 }
             },
+            targetFps: {
+                get() {
+                    return this.$store.state.gui.webcam.targetFps;
+                },
+                set(fps) {
+                    return this.$store.dispatch('gui/setSettings', { webcam: { targetFps: fps } });
+                }
+            }
         },
         methods: {
 

--- a/src/components/panels/Settings/WebcamPanel.vue
+++ b/src/components/panels/Settings/WebcamPanel.vue
@@ -45,10 +45,10 @@
                 </v-row>
                 <v-row>
                     <v-col class="py-2">
-                        <v-switch v-model="adaptiveFps" hide-details label="(Experimental) Adaptive FPS" class="mt-0"></v-switch>
+                        <v-select v-model="serviceMethod" :items="serviceMethodItems" hide-details label="Service Method" class="mt-0"></v-select>
                     </v-col>
                 </v-row>
-                <v-row v-if="adaptiveFps">
+                <v-row v-if="serviceMethod == 1">
                     <v-col class="py-2">
                         <v-text-field v-model="targetFps" hide-details label="Target FPS" class="mt-0"></v-text-field>
                     </v-col>
@@ -65,7 +65,11 @@
         },
         data: function() {
             return {
-                rotationEnabled: false
+                rotationEnabled: false,
+                serviceMethodItems: [
+                    { value: 0, text: 'MJPEG-Streamer' },
+                    { value: 1, text: 'MJPEG-Streamer (Adaptive)' },
+                ]
             }
         },
         computed: {
@@ -74,8 +78,6 @@
                     return this.$store.state.gui.webcam.url;
                 },
                 set(url) {
-                    if(this.$store.state.gui.webcam.adaptiveFps)
-                        url = url.replace("action=stream", "action=snapshot");
                     return this.$store.dispatch('gui/setSettings', { webcam: { url } });
                 }
             },
@@ -119,12 +121,12 @@
                     return this.$store.dispatch('gui/setSettings', { webcam: { bool: showNav } });
                 }
             },
-            adaptiveFps: {
+            serviceMethod: {
                 get() {
-                    return this.$store.state.gui.webcam.adaptiveFps;
+                    return this.$store.state.gui.webcam.serviceMethod;
                 },
-                set(useAdaptiveFps) {
-                    return this.$store.dispatch('gui/setSettings', { webcam: { adaptiveFps: useAdaptiveFps } });
+                set(selectedMethod) {
+                    return this.$store.dispatch('gui/setSettings', { webcam: { serviceMethod: selectedMethod } });
                 }
             },
             targetFps: {

--- a/src/components/panels/Settings/WebcamPanel.vue
+++ b/src/components/panels/Settings/WebcamPanel.vue
@@ -43,6 +43,11 @@
                         <v-switch v-model="boolNavi" hide-details label="Show in navigation" class="mt-0"></v-switch>
                     </v-col>
                 </v-row>
+                <v-row>
+                    <v-col class="py-2">
+                        <v-switch v-model="boolWebsocket" hide-details label="Use Websocket Method" class="mt-0"></v-switch>
+                    </v-col>
+                </v-row>
             </v-container>
         </v-card-text>
     </v-card>
@@ -105,6 +110,14 @@
                 },
                 set(showNav) {
                     return this.$store.dispatch('gui/setSettings', { webcam: { bool: showNav } });
+                }
+            },
+            boolWebsocket: {
+                get() {
+                    return this.$store.state.gui.webcam.boolWebsocket;
+                },
+                set(useWebsocket) {
+                    return this.$store.dispatch('gui/setSettings', { webcam: { boolWebsocket: useWebsocket } });
                 }
             },
         },

--- a/src/components/panels/WebcamPanel.vue
+++ b/src/components/panels/WebcamPanel.vue
@@ -40,7 +40,7 @@
             document.addEventListener("focus", () => this.handleRefreshChange(), false);
             document.addEventListener("visibilitychange", this.handleRefreshChange, false);
 
-            if(this.webcamConfig.adaptiveFps) {
+            if(this.webcamConfig.serviceMethod == 1) {
                 this.requestMjpeg();
             }
 
@@ -54,11 +54,11 @@
             }),
 
             subHeading() {
-                return "Webcam" + (this.webcamConfig.adaptiveFps ? " - FPS: " + Math.round(1000 / this.time) : "");
+                return "Webcam" + (this.webcamConfig.serviceMethod == 1 ? " - FPS: " + Math.round(1000 / this.time) : "");
             },
 
             url() {
-                if(!this.webcamConfig.adaptiveFps) {
+                if(!this.webcamConfig.serviceMethod) {
                     let basicUrl = this.webcamConfig.url
                     if (basicUrl && basicUrl.indexOf("?") === -1) basicUrl += "?"
 
@@ -67,10 +67,6 @@
                     return decodeURIComponent(params.toString())
                 } else {
                     return this.imageData;
-                    /*return 'data:image/jpeg;base64,' + btoa(
-                        new Uint8Array(this.blobData)
-                            .reduce((data, byte) => data.String.fromCharCode(byte), '')
-                    )*/
                 }
             },
 
@@ -121,6 +117,7 @@
             requestMjpeg() {
                 if(!this.isVisible)
                     return;
+
                 this.request_start_time = performance.now();
                 let basicUrl = this.webcamConfig.url
                 if (basicUrl && basicUrl.indexOf("?") === -1) basicUrl += "?"
@@ -133,9 +130,8 @@
                 })
             },
 
-            visibilityChanged(isVisible, entry) {
+            visibilityChanged(isVisible) {
                 this.isVisible = isVisible;
-                console.log(entry);
                 if(isVisible)
                     this.requestMjpeg();
             }

--- a/src/main.js
+++ b/src/main.js
@@ -7,10 +7,12 @@ import './components'
 import store from './store'
 import router from './plugins/router'
 import vueHeadful from 'vue-headful';
+import VueObserveVisibility from 'vue-observe-visibility';
 
 Vue.config.productionTip = false;
 
 Vue.use(VueResource);
+Vue.use(VueObserveVisibility);
 Vue.http.headers.common['Content-Type'] = 'application/json';
 Vue.http.headers.common['Access-Control-Allow-Origin'] = '*';
 Vue.http.headers.common['Accept'] = 'application/json, text/plain, */*';


### PR DESCRIPTION
As some of you may know, with the native MJPEG Streaming implementation *every* frame is sent from the server to the client. This can cause a slow-down (and subsequent speed-up) phenomenon for the client, if the bandwidth is not sufficient. Sometimes causing the stream being seen to be 2 minutes in the past.

Therefore I've implemented a pull-based method for frames, where the client only requests a new frame once the previous one has finished loading. With a bit of a limiter and smoothing put in place to hit a desired target fps, **very** heavily inspired by [PyImageStream](https://github.com/Bronkoknorb/PyImageStream), which I've tried out previously but noticed a very high CPU usage (~60% load on a Pi3 😬) --- probably due to its pygame dependency for frame grabbing, which is known to be rather inefficient.

If MJPEG-Streamer is used, with the adaptive fps method selected in mainsail, you should be using the `?action=snapshot` endpoint. I'm not sure if straight up overriding `?action=stream` in the url is a nice approach, so it's up to the user to supply the right URL.

Keep-Alive or h2c/http2 should be used to reuse previously opened connections, as to not incur an overhead cost by constantly creating new connections.

Suggestions are welcome, I'm not much of a webdev and haven't used vue.js before.

Settings menu: 
![image](https://user-images.githubusercontent.com/2448290/107966245-dd6e0d80-6fab-11eb-978d-d1799902d996.png)
Webcam panel with frame skipping enabled in action on a flakey wifi connection that freezes every couple seconds: https://streamable.com/i6473c