### PR TITLE
docs: add home and temp check to PAUSE and RESUME

### DIFF
--- a/docs/necessary-cfg.md
+++ b/docs/necessary-cfg.md
@@ -77,6 +77,9 @@ rename_existing: BASE_RESUME
 gcode:
     ##### set defaults #####
     {% set e = params.E|default(1) %} #edit to your retract length
+    {%set min_extrude_temp = printer.configfile.settings["extruder"]["min_extrude_temp"]|int %}
+    {%set act_extrude_temp = printer.extruder.temperature|int %}
+    ##### end of definitions #####
     G91
     {% if act_extrude_temp > min_extrude_temp %}
       G1 E{e} F2100

--- a/docs/necessary-cfg.md
+++ b/docs/necessary-cfg.md
@@ -81,6 +81,12 @@ gcode:
     {% set e = params.E|default(1) %} #edit to your retract length
     {%set min_extrude_temp = printer.configfile.settings["extruder"]["min_extrude_temp"]|int %}
     {%set act_extrude_temp = printer.extruder.temperature|int %}
+    #### get VELOCITY parameter if specified ####
+    {% if 'VELOCITY' in params|upper %}
+      {% set get_params = ('VELOCITY=' + params.VELOCITY)  %}
+    {%else %}
+      {% set get_params = "" %}
+    {% endif %}
     ##### end of definitions #####
     G91
     {% if act_extrude_temp > min_extrude_temp %}
@@ -89,7 +95,7 @@ gcode:
       {action_respond_info("Extruder not hot enough")}
     {% endif %}  
     RESTORE_GCODE_STATE NAME=PAUSE_state MOVE=1
-    RESUME_BASE
+    RESUME_BASE {get_params}
 ```
 
 

--- a/docs/necessary-cfg.md
+++ b/docs/necessary-cfg.md
@@ -55,7 +55,6 @@ gcode:
     {%set min_extrude_temp = printer.configfile.settings["extruder"]["min_extrude_temp"]|int %}
     {%set act_extrude_temp = printer.extruder.temperature|int %}
     ##### end of definitions #####
-    SAVE_GCODE_STATE NAME=PAUSE_state
     PAUSE_BASE
     G91
     {% if act_extrude_temp > min_extrude_temp %}
@@ -94,7 +93,6 @@ gcode:
     {% else %}
       {action_respond_info("Extruder not hot enough")}
     {% endif %}  
-    RESTORE_GCODE_STATE NAME=PAUSE_state MOVE=1
     RESUME_BASE {get_params}
 ```
 

--- a/docs/necessary-cfg.md
+++ b/docs/necessary-cfg.md
@@ -35,7 +35,8 @@ These should be modified to your own needs.
 {% raw %}
 ```yaml
 [gcode_macro PAUSE]
-rename_existing: BASE_PAUSE
+description: Pause the actual running print
+rename_existing: PAUSE_BASE
 gcode:
     ##### set defaults #####
     {% set x = params.X|default(230) %}      #edit to your park position
@@ -55,7 +56,7 @@ gcode:
     {%set act_extrude_temp = printer.extruder.temperature|int %}
     ##### end of definitions #####
     SAVE_GCODE_STATE NAME=PAUSE_state
-    BASE_PAUSE
+    PAUSE_BASE
     G91
     {% if act_extrude_temp > min_extrude_temp %}
       G1 E-{e} F2100
@@ -73,7 +74,8 @@ gcode:
 
 ```yaml
 [gcode_macro RESUME]
-rename_existing: BASE_RESUME
+description: Resume the actual running print
+rename_existing: RESUME_BASE
 gcode:
     ##### set defaults #####
     {% set e = params.E|default(1) %} #edit to your retract length
@@ -87,18 +89,19 @@ gcode:
       {action_respond_info("Extruder not hot enough")}
     {% endif %}  
     RESTORE_GCODE_STATE NAME=PAUSE_state MOVE=1
-    BASE_RESUME
+    RESUME_BASE
 ```
 
 
 ```yaml
 [gcode_macro CANCEL_PRINT]
-rename_existing: BASE_CANCEL_PRINT
+description: Cancel the actual running print
+rename_existing: CANCEL_PRINT_BASE
 gcode:
     TURN_OFF_HEATERS
     CLEAR_PAUSE
     SDCARD_RESET_FILE
-    BASE_CANCEL_PRINT
+    CANCEL_PRINT_BASE
 ```
 {% endraw %}
 


### PR DESCRIPTION
add home and temperature check to the default macros. This will avoid errors if PAUSE or RESUME is executed while not homed or extruder below minimum temperature.

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com