### PR TITLE
bugfix: fix the webcam panel collapsible property

### DIFF
--- a/src/components/panels/WebcamPanel.vue
+++ b/src/components/panels/WebcamPanel.vue
@@ -7,7 +7,7 @@
         v-if="socketIsConnected"
         icon="mdi-webcam"
         :title="$t('Panels.WebcamPanel.Headline')"
-        :collapsible="true"
+        :collapsible="(this.$route.fullPath !== '/cam')"
         card-class="webcam-panel"
     >
         <template v-slot:buttons v-if="webcams.length > 1">


### PR DESCRIPTION
This fixes a bug where the webcam panel is collapsible even when navigated to the webcam page where the panel should not be collapsible.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>