### PR TITLE
feat: add option to hide config backup files

### DIFF
--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -43,6 +43,9 @@
                                 <v-list-item class="minHeight36">
                                     <v-checkbox class="mt-0" hide-details v-model="showHiddenFiles" :label="$t('Machine.ConfigFilesPanel.HiddenFiles')"></v-checkbox>
                                 </v-list-item>
+                                <v-list-item class="minHeight36">
+                                    <v-checkbox class="mt-0" hide-details v-model="hideBackupFiles" :label="$t('Machine.ConfigFilesPanel.HideBackupFiles')"></v-checkbox>
+                                </v-list-item>
                             </v-list>
                         </v-menu>
                     </v-col>
@@ -468,6 +471,14 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin) {
         this.$store.dispatch('gui/saveSetting', { name: 'settings.configfiles.showHiddenFiles', value: newVal })
     }
 
+    get hideBackupFiles() {
+        return this.$store.state.gui.settings.configfiles.hideBackupFiles
+    }
+
+    set hideBackupFiles(newVal) {
+        this.$store.dispatch('gui/saveSetting', { name: 'settings.configfiles.hideBackupFiles', value: newVal })
+    }
+
     get sortBy() {
         return this.$store.state.gui.settings.configfiles.sortBy
     }
@@ -526,6 +537,11 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin) {
 
         if (!this.showHiddenFiles) {
             this.files = this.files.filter(file => file.filename.substr(0, 1) !== '.')
+        }
+
+        if (this.hideBackupFiles) {
+            const backupFileMatcher = /.*\/?printer-\d{8}_\d{6}\.cfg$/
+            this.files = this.files.filter(file => !file.filename.match(backupFileMatcher))
         }
     }
 
@@ -806,5 +822,8 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin) {
 
     @Watch('showHiddenFiles')
     showHiddenFilesChanged() { this.loadPath() }
+
+    @Watch('hideBackupFiles')
+    hideBackupFilesChanged() { this.loadPath() }
 }
 </script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -397,6 +397,7 @@
 			"ConfigFiles": "Config Files",
 			"SetupCurrentList": "Setup current list",
 			"HiddenFiles": "Hidden files",
+			"HideBackupFiles": "Hide backup files",
 			"CurrentPath": "Current path",
 			"Files": "Files",
 			"FreeDisk": "Free disk",

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -157,6 +157,7 @@ export const getDefaultState = (): GuiState => {
                 sortBy: 'filename',
                 sortDesc: false,
                 showHiddenFiles: false,
+                hideBackupFiles: false
             }
         },
         editor: {


### PR DESCRIPTION
This PR adds an option to hide config backup files.

![Screenshot 2021-10-12 at 22 53 06](https://user-images.githubusercontent.com/1850271/137029122-cb496013-b8bd-4bbf-ac33-ad513572e41b.png)
![Screenshot 2021-10-12 at 22 53 18](https://user-images.githubusercontent.com/1850271/137029115-05f75824-aae2-4b43-b46a-34bd98bcc925.png)

