### PR TITLE
fix: close websocket before connecting

### DIFF
--- a/src/plugins/webSocketClient.ts
+++ b/src/plugins/webSocketClient.ts
@@ -33,6 +33,10 @@ export class WebSocketClient {
 
     connect(): void {
         this.store?.dispatch('socket/setData', { isConnecting: true })
+
+        if (this.instance) {
+            this.instance.close()
+        }
         this.instance = new WebSocket(this.url)
 
         this.instance.onopen = () => {


### PR DESCRIPTION
When switching between printers the Websocket seems not to get closed reliably.
One effect of this is that you get duplicate messages in the console.

![Screenshot 2021-10-20 at 14 36 24](https://user-images.githubusercontent.com/1850271/138097923-7abdc3f6-de72-44b0-a0bf-5b90ca772251.png)
.
