### PR TITLE
feat: uses monospace font on console

### DIFF
--- a/src/components/console/ConsoleTableEntry.vue
+++ b/src/components/console/ConsoleTableEntry.vue
@@ -1,5 +1,6 @@
 <style scoped lang="scss">
     .consoleTableRow {
+        font-family: monospace;
 
         &+.consoleTableRow .col {
             border-top: 1px solid rgba(255, 255, 255, 0.12);

--- a/src/components/panels/MiniconsolePanel.vue
+++ b/src/components/panels/MiniconsolePanel.vue
@@ -3,6 +3,10 @@
     .consoleTable {
         border-top: 1px solid rgba(255, 255, 255, 0.12);
     }
+
+    .gcode-command-field {
+        font-family: monospace;
+    }
 </style>
 
 <template>

--- a/src/pages/Console.vue
+++ b/src/pages/Console.vue
@@ -5,6 +5,9 @@
     height: calc(100vh - 180px);
 }
 
+.gcode-command-field {
+    font-family: monospace;
+}
 </style>
 
 <template>


### PR DESCRIPTION
Fixes #388 by changing the font on the console input and output to "monospace" (fixed-width)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>