### PR TITLE
feat: Added modified file tracking and unsaved change

### DIFF
--- a/src/components/TheSettingsMenu.vue
+++ b/src/components/TheSettingsMenu.vue
@@ -59,6 +59,8 @@ import SettingsRemotePrintersTab from '@/components/settings/SettingsRemotePrint
 import SettingsThemeTab from '@/components/settings/SettingsThemeTab.vue'
 import SettingsDashboardTab from '@/components/settings/SettingsDashboardTab.vue'
 import SettingsGCodeViewerTab from '@/components/settings/SettingsGCodeViewerTab.vue'
+import SettingsEditorTab from '@/components/settings/SettingsEditorTab.vue'
+
 import Panel from '@/components/ui/Panel.vue'
 @Component({
     components: {
@@ -72,7 +74,8 @@ import Panel from '@/components/ui/Panel.vue'
         SettingsWebcamTab,
         SettingsGeneralTab,
         SettingsDashboardTab,
-        SettingsGCodeViewerTab
+        SettingsGCodeViewerTab,
+        SettingsEditorTab
     }
 })
 export default class TheSettingsMenu extends Mixins(BaseMixin) {
@@ -134,6 +137,11 @@ export default class TheSettingsMenu extends Mixins(BaseMixin) {
                 icon: 'mdi-video-3d',
                 name: 'g-code-viewer',
                 title: this.$t('Settings.GCodeViewerTab.GCodeViewer')
+            },
+            {
+                icon: 'mdi-file-document-edit-outline',
+                name: 'editor',
+                title: this.$t('Settings.EditorTab.Editor')
             }
         ]
     }

--- a/src/components/settings/SettingsEditorTab.vue
+++ b/src/components/settings/SettingsEditorTab.vue
@@ -1,0 +1,45 @@
+<template>
+    <div>
+        <v-card flat>
+            <v-card-text>
+                <settings-row :title="$t('Settings.EditorTab.UseEscToClose')" :sub-title="$t('Settings.EditorTab.UseEscToCloseDescription')" :dynamicSlotWidth="true">
+                    <v-switch v-model="escToClose" hide-details class="mt-0"></v-switch>
+                </settings-row>
+                <v-divider class="my-2"></v-divider>
+                <settings-row :title="$t('Settings.EditorTab.ConfirmUnsavedChanges')" :sub-title="$t('Settings.EditorTab.ConfirmUnsavedChangesDescription')" :dynamicSlotWidth="true">
+                    <v-switch v-model="confirmUnsavedChanges" hide-details class="mt-0"></v-switch>
+                </settings-row>
+                <v-divider class="my-2"></v-divider>
+            </v-card-text>
+        </v-card>
+    </div>
+</template>
+
+<script lang="ts">
+
+import Component from 'vue-class-component'
+import { Mixins } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import SettingsRow from '@/components/settings/SettingsRow.vue'
+@Component({
+    components: {SettingsRow}
+})
+export default class SettingsEditorTab extends Mixins(BaseMixin) {
+
+    get escToClose() {
+        return this.$store.state.gui.editor.escToClose
+    }
+
+    set escToClose(newVal) {
+        this.$store.dispatch('gui/saveSetting', {name: 'editor.escToClose', value: newVal })
+    }
+
+    get confirmUnsavedChanges() {
+        return this.$store.state.gui.editor.confirmUnsavedChanges
+    }
+
+    set confirmUnsavedChanges(newVal) {
+        this.$store.dispatch('gui/saveSetting', {name: 'editor.confirmUnsavedChanges', value: newVal })
+    }
+}
+</script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -105,7 +105,12 @@
 		"SaveRestart": "Save & Restart",
 		"SaveClose": "Save & close",
 		"SuccessfullySaved": "{filename} successfully saved.",
-		"FailedSave": "{filename} could not be uploaded!"
+		"FailedSave": "{filename} could not be uploaded!",
+		"UnsavedChanges": "Unsaved Changes",
+		"UnsavedChangesMessage": "Do you want to save your changes made to {filename}?",
+		"UnsavedChangesSubMessage": "Your changes will be lost if you don't save them. You can disable this message in the editor settings.",
+		"DontSave": "Don't save",
+		"Cancel": "Cancel"
 	},
 	"Files": {
 		"GCodeFiles": "G-Code Files",
@@ -632,6 +637,13 @@
 			"ShowAxes": "Show Axes",
 			"MinFeed" :"Min Feed Rate",
 			"MaxFeed" : "Max Feed Rate"
+		},
+		"EditorTab": {
+			"Editor": "Editor",
+			"UseEscToClose": "Use ESC to close editor",
+			"UseEscToCloseDescription": "Allows the ESC key to close the editor",
+			"ConfirmUnsavedChanges": "Prompt to save or discard unsaved changes",
+			"ConfirmUnsavedChangesDescription": "If enabled, the editor requires a confirmation to either save or discard the changes made. If disabled, changes are silently discarded."
 		}
 	},
 	"GCodeViewer":{

--- a/src/store/editor/index.ts
+++ b/src/store/editor/index.ts
@@ -20,7 +20,9 @@ export const getDefaultState = (): EditorState => {
             total: 0,
             speed: '',
         },
-        cancelToken: null
+        cancelToken: null,
+        loadedHash: '',
+        changed: false
     }
 }
 

--- a/src/store/editor/mutations.ts
+++ b/src/store/editor/mutations.ts
@@ -2,8 +2,10 @@ import { getDefaultState } from './index'
 import {MutationTree} from 'vuex'
 import {EditorState} from '@/store/editor/types'
 import Vue from 'vue'
+import { sha256 } from 'js-sha256'
 
 export const mutations: MutationTree<EditorState> = {
+    
     reset(state) {
         Object.assign(state, getDefaultState())
     },
@@ -25,6 +27,13 @@ export const mutations: MutationTree<EditorState> = {
         Vue.set(state, 'fileroot', payload.fileroot)
         Vue.set(state, 'filepath', payload.filepath)
         Vue.set(state, 'sourcecode', payload.file)
+
+        // Because the used editor converts all Windows-Style line endings with unix ones on load,
+        // the hash is computed with the source always having unix-style line endings.
+        // https://github.com/codemirror/CodeMirror/issues/3395
+
+        Vue.set(state, 'loadedHash', sha256(payload.file.replace(/(?:\r\n|\r|\n)/g, '\n')))
+        Vue.set(state, 'changed', false)
         Vue.set(state, 'bool', true)
     },
 
@@ -42,5 +51,24 @@ export const mutations: MutationTree<EditorState> = {
 
     updateSourcecode(state, payload) {
         Vue.set(state, 'sourcecode', payload)
+
+        // To check if a file has been changed by the user, we need to calculate a hash
+        // (or otherwise we would need to save the full file in memory twice). Simply listening
+        // to the changed event is not enough, because if the user types an "a" and then deletes
+        // the "a" again, the file would still be shown as changed, even though the edited file
+        // is equal to the stored file.
+
+        // I've tested this functionality with huge text files (60MB G-Code) and while calculating
+        // the hash took 2 seconds per run, the editor itself is pretty laggy even without hash
+        // calculations. Hash calculations with typical config file sizes (50KB) only take 1 or 2ms
+        // on my machine, so I guess this is acceptable for most use cases.
+        
+        if (sha256(payload) != state.loadedHash)
+            state.changed = true
+        else
+            state.changed = false
     }
+
 }
+
+

--- a/src/store/editor/types.ts
+++ b/src/store/editor/types.ts
@@ -13,5 +13,7 @@ export interface EditorState {
         total: number
         speed: string
     },
-    cancelToken: any
+    cancelToken: any,
+    loadedHash: string,
+    changed: boolean
 }

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -165,7 +165,9 @@ export const getDefaultState = (): GuiState => {
             }
         },
         editor: {
-            minimap: false
+            minimap: false,
+            escToClose: true,
+            confirmUnsavedChanges: true
         },
         //moonraker DB api dont accept camel case key names
         remotePrinters: [],
@@ -192,7 +194,7 @@ export const getDefaultState = (): GuiState => {
             voxelWidth: 1,
             voxelHeight: 1,
             specularLighting: false,
-        }
+        },
     }
 }
 


### PR DESCRIPTION
This PR implements a configurable confirmation dialog if unsaved changes would be discarded in the editor. This PR also implements a config option to prevent ESC to close the editor.

### Added Features
- File Changed Indicator (the well-known Asterisk `*`)
- Confirmation dialog if the user attempts to close the editor with unsaved changes with the following options
  - `Cancel` to continue editing
  - `Don't save` to close the editor without saving the changes
  - `Save & Close` to close the editor and saving the changes (same as in the top bar)
  - `Save & Restart` if the config file affects a restartable service (same as in the top bar)
- Confirmation dialog can be disabled to make the system behave like in previous versions
- `ESC` key can be disabled to prevent accidental closing of the editor

### Implementation Notes
- This PR calculates a hash of the loaded file to compare it against the actual editor content to reliably show if the content has been edited or not.
  - The used editor only fires an event if the content has been changed, but this doesn't allow the PR to check if that change has been reverted
  - Example: If the user types an `a`, the editor would fire the "changed" event. If the user now deletes the `a`, the editor would fire the "changed" event again, and the file would be shown as changed, even though the change was reverted.
- Because the used editor always uses Unix-style newlines, even if the original file has Windows-style newlines, the file would immediately be shown as changed. Due to that, the PR converts all newlines to Unix-style newlines prior the hash calculation.
- The hash calculation is reasonably fast for small files (1-2ms at a file size of 50kb), but significantly slows down with huge G-Code files (2 seconds for 60MB of G-Code). However, even without the hash calculation the editor is slow with huge G-Code files, so this shouldn't matter too much.
- The default settings are:
  - `[x]` Use ESC to close editor
  - `[x]` Prompt to save or discard unsaved changes
  - The reason behind the defaults is to have new users benefit from the "Prompt unsaved changes" dialog, whilst users preferring not to be nagged by the dialog can turn it off. If the default was to disable the "Prompt unsaved changes" dialog, new users would not be aware of this feature and potentially loosing their changes by accident.
 
### Screenshots
![image](https://user-images.githubusercontent.com/162974/138864299-286edac2-56ce-4835-a686-5b105a45c6e1.png)
![image](https://user-images.githubusercontent.com/162974/138865380-98293a16-6109-4388-9063-f8c371682603.png)
