### PR TITLE
fix: Search string highlighted after pressing Ctrl+F again

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@codemirror/state": "^0.19.1",
     "@codemirror/stream-parser": "^0.19.1",
     "@codemirror/view": "^0.19.1",
+    "@codemirror/search": "^0.19.2",
     "@sindarius/gcodeviewer": "^2.1.13",
     "axios": "^0.21.1",
     "core-js": "^3.16.0",


### PR DESCRIPTION
This PR bumps the version for @codemirror/search 0.19.2:

> Make sure any existing search text is selected when opening the search panel. Add search config option to not match case when search panel is opened (#4)

Original problem:
- If `Ctrl+F` is hit once, and some search string is entered, a subsequent `Ctrl+F` doesn't highlight the previous search string, so everything typed is appended. The usual implementation of `Ctrl+F` is to mark the text in the text box, so that it can be easily overwritten
-- Example: If I hit `Ctrl+F`, then search for "bed", then hit `Ctrl+F` again and type "temp", the search input box would contain "bedtemp" instead of "temp".

As a bonus, case insensitive search is now the default and is configurable. If wanted, I can add an option to mainsail to enable case sensitive search.