### PR TITLE
fix: add more space between the rows in manual probe window

### DIFF
--- a/src/components/dialogs/TheManualProbeDialog.vue
+++ b/src/components/dialogs/TheManualProbeDialog.vue
@@ -62,7 +62,7 @@
                             <span>&plus;{{ offset }}</span>
                         </v-btn>
                     </v-item-group>
-                    <v-item-group class="_btn-group mt-3">
+                    <v-item-group class="_btn-group mt-6 mt-sm-3">
                         <v-btn
                             v-for="(offset, index) in offsetsZ"
                             :key="`offsetsDown-${index}`"


### PR DESCRIPTION
fix only in mobile view. this PR fix #1183

old:
![Bildschirmfoto 2022-12-09 um 21 38 06](https://user-images.githubusercontent.com/8167632/206792918-743f91ae-c7da-4cd0-8500-57f89cf4362a.png)

new:
![Bildschirmfoto 2022-12-09 um 21 40 10](https://user-images.githubusercontent.com/8167632/206792937-5d874b4b-7dbf-40b8-ba4f-59984ccc37ad.png)

Signed-off-by: Stefan Dej <meteyou@gmail.com>