### PR TITLE
fix korean locale

### DIFF
--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -12,7 +12,7 @@
                 "KlipperWarning": "클리퍼 : 주의"
             },
             "MoonrakerWarnings": {
-                "MoonrakerComponent": "문레이커: {component}",
+                "MoonrakerComponent": "문레이커:{component}",
                 "MoonrakerFailedComponentDescription": "문레이커 구성 요소인 '{component}'을(를) 로드하는 동안 오류가 발생했습니다 로 파일을 확인해 문제를 해결해 주세요",
                 "MoonrakerWarning": "문레이커 : 주의",
                 "UnparsedConfigOption": "[{section}]에서 사용할 수 없는 구성 옵션인 '{option}:{value}'이(가) 존재하며 이는 더 이상 사용할 수 없는 옵션 또는 모듈 로딩을 할 수 없는 경우이며 이제부터 시작 오류가 발생할 수 있습니다",


### PR DESCRIPTION
There was a json modification error due to the i18n conversion tool problem and it was attached as LF, not CRLF with UTF-8(prettier on VSCode. so i fixed up it and uploaded again. (also remove 2 unused keys)