### PR TITLE
feat(AFC): Adding togglable setting to AFC panel to display toolchange count

### DIFF
--- a/src/components/mixins/afc.ts
+++ b/src/components/mixins/afc.ts
@@ -100,6 +100,10 @@ export default class AfcMixin extends Vue {
         return this.$store.state.gui.view.afc?.hiddenUnits ?? []
     }
 
+    get afcShowToolChangeCount(): boolean {
+        return this.$store.state.gui.view.afc?.showToolChangeCount ?? true
+    }
+
     getPrinterObject(key: string) {
         const printer = this.$store.state.printer ?? {}
         return printer[key] ?? null
@@ -141,5 +145,9 @@ export default class AfcMixin extends Vue {
     getAfcHubObject(hub: string) {
         const key = `AFC_hub ${hub}`
         return this.getPrinterObject(key) ?? {}
+    }
+
+    get currentFilamentChange() {
+        return this.$store.state.printer.AFC?.current_toolchange ?? null
     }
 }

--- a/src/components/panels/Afc/AfcPanelSettings.vue
+++ b/src/components/panels/Afc/AfcPanelSettings.vue
@@ -27,6 +27,13 @@
                     hide-details
                     :label="$t('Panels.AfcPanel.ShowUnitIcons')" />
             </v-list-item>
+            <v-list-item class="minHeight36">
+                <v-checkbox
+                    v-model="showToolChangeCount"
+                    class="mt-0"
+                    hide-details
+                    :label="$t('Panels.AfcPanel.ShowToolChangeCount')" />
+            </v-list-item>
             <v-divider />
             <afc-panel-settings-extruder v-for="extruder in afcExtruders" :key="extruder" :name="extruder" />
             <afc-panel-settings-unit v-for="unit in afcUnits" :key="unit" :name="unit" />
@@ -57,6 +64,14 @@ export default class AfcPanelSettings extends Mixins(BaseMixin, AfcMixin) {
 
     set showLaneInfinite(value: boolean) {
         this.$store.dispatch('gui/saveSetting', { name: 'view.afc.showLaneInfinite', value })
+    }
+
+    get showToolChangeCount(): boolean {
+        return this.$store.state.gui.view.afc?.showToolChangeCount ?? true
+    }
+
+    set showToolChangeCount(value: boolean) {
+        this.$store.dispatch('gui/saveSetting', { name: 'view.afc.showToolChangeCount', value })
     }
 
     get showUnitIcons(): boolean {

--- a/src/components/panels/Status/PrintstatusPrinting.vue
+++ b/src/components/panels/Status/PrintstatusPrinting.vue
@@ -41,10 +41,10 @@
                     <v-tooltip top>
                         <template #activator="{ on, attrs }">
                             <div v-bind="attrs" v-on="on">
-                                <strong>{{ $t('Panels.StatusPanel.Filament') }}</strong>
+                                <strong>{{ filamentToolchangeText }}</strong>
                                 <br />
                                 <span class="d-block text-center text-no-wrap">
-                                    {{ outputFilamentUsed }}
+                                    {{ filamentToolChangeBody }}
                                 </span>
                             </div>
                         </template>
@@ -135,6 +135,7 @@
 import Component from 'vue-class-component'
 import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
+import AfcMixin from '@/components/mixins/afc'
 import StatusPanelFilesJobqueue from '@/components/panels/Status/Jobqueue.vue'
 import StatusPanelFilesGcodes from '@/components/panels/Status/Gcodefiles.vue'
 
@@ -144,7 +145,7 @@ import StatusPanelFilesGcodes from '@/components/panels/Status/Gcodefiles.vue'
         StatusPanelFilesGcodes,
     },
 })
-export default class StatusPanelPrintstatusPrinting extends Mixins(BaseMixin) {
+export default class StatusPanelPrintstatusPrinting extends Mixins(BaseMixin, AfcMixin) {
     private maxFlow: number = 0
 
     get current_file() {
@@ -232,10 +233,33 @@ export default class StatusPanelPrintstatusPrinting extends Mixins(BaseMixin) {
         return this.$store.state.printer.print_stats?.filament_used ?? 0
     }
 
-    get outputFilamentUsed() {
+    get filamentToolchangeText() {
+        if (this.afc && this.afcShowToolChangeCount && this.current_file.filament_change_count > 0) {
+            return this.$t('Panels.StatusPanel.Toolchange')
+        } else {
+            return this.$t('Panels.StatusPanel.Filament')
+        }
+    }
+
+    get filamentToolChangeBody() {
+        if (this.afc && this.afcShowToolChangeCount && this.current_file.filament_change_count > 0) {
+            return this.toolChangeCount()
+        } else {
+            return this.outputFilamentUsed()
+        }
+    }
+
+    outputFilamentUsed() {
         return this.filament_used >= 1000
             ? (this.filament_used / 1000).toFixed(2) + ' m'
             : this.filament_used.toFixed(2) + ' mm'
+    }
+
+    toolChangeCount() {
+        if (this.afc && this.current_file.filament_change_count > 0) {
+            return `${this.currentFilamentChange} / ${this.current_file.filament_change_count}`
+        }
+        return 0
     }
 
     formatDuration(seconds: number) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -679,6 +679,7 @@
             "ShowFilamentName": "Show Filament Name",
             "ShowLaneInfinite": "Show Infinite Button",
             "ShowTool": "Show Tool \"{name}\"",
+            "ShowToolChangeCount": "Show Toolchange Count",
             "ShowUnit": "Show Unit \"{name}\"",
             "ShowUnitIcons": "Show Unit Icons",
             "Unloading": "Unloading",
@@ -855,6 +856,7 @@
             "ResumePrint": "Resume print",
             "Slicer": "Slicer",
             "Speed": "Speed",
+            "Toolchange": "Toolchange",
             "Total": "Total",
             "TotalTime": "Total Time",
             "Unknown": "Unknown"

--- a/src/store/gui/index.ts
+++ b/src/store/gui/index.ts
@@ -196,6 +196,7 @@ export const getDefaultState = (): GuiState => {
                 showFilamentName: false,
                 showLaneInfinite: true,
                 showUnitIcons: true,
+                showToolChangeCount: true,
             },
             blockFileUpload: false,
             configfiles: {

--- a/src/store/gui/types.ts
+++ b/src/store/gui/types.ts
@@ -138,6 +138,7 @@ export interface GuiState {
             showFilamentName: boolean
             showLaneInfinite: boolean
             showUnitIcons: boolean
+            showToolChangeCount: boolean
         }
         blockFileUpload: boolean
         configfiles: {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your Pull Request already received reviews or comments.

  For a clean commit history, we squash-merge Pull Requests. The Pull Request title then becomes the commit message.
  Therefore, we advise to have the PR title in form of the Conventional Commits specification.
  We use the following prefixes for the PR title:
    - feat: A new feature
    - fix: A bug fix
    - docs: Changes that only affect documentation
    - style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    - refactor: A code change that neither fixes a bug nor adds a feature
    - perf: A code change that improves performance
    - test: Adding missing tests or correcting existing tests
    - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
    - locale: Changes to the translations

  You can find more information about Conventional Commits here: https://www.conventionalcommits.org/en/v1.0.0/.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Mainsail Contributing Guidelines: https://github.com/mainsail-crew/mainsail/blob/HEAD/CONTRIBUTING.md#-submitting-a-pull-request-pr
  - 📖 Read the Mainsail Code of Conduct: https://github.com/mainsail-crew/mainsail/blob/HEAD/.github/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small Pull Requests that only address one issue or feature
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update any related documentation and include any relevant screenshots
-->

## Description
- Adds togglable setting to AFC panel to display toolchange count in print stats box
  - Filament usage tooltip will still display when toolchange is displayed

## Related Tickets & Documents
None
<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

https://github.com/user-attachments/assets/d41677a1-7012-4aa9-8a42-ae9fc5e9d840

## [optional] Are there any post-deployment tasks we need to perform?
- A fix will be implemented in AFC-Klipper-Add-On so that current toolchange value will return 0 instead of -1
