### PR TITLE
fix: remove debug console output in MiscellaneousLightNeopixelDialog.vue

### DIFF
--- a/src/components/dialogs/MiscellaneousLightNeopixelDialog.vue
+++ b/src/components/dialogs/MiscellaneousLightNeopixelDialog.vue
@@ -166,8 +166,6 @@ export default class MiscellaneousLightNeopixelDialog extends Mixins(BaseMixin) 
             return { ...value, id: key }
         })
 
-        window.console.log(presets)
-
         return caseInsensitiveSort(presets, 'name')
     }
 


### PR DESCRIPTION
## Description

This PR just remove a unused console output in the MiscellaneousLightNeopixelDialog.vue.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
