### PR TITLE
chore(Docker): remove mainsail.zip from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN npm ci
 
 COPY ./ /app/
 
-RUN npm run build
+RUN npm run build && rm /app/dist/mainsail.zip
 
 # set port to >1024 port for non root running
 RUN sed 's/80/8080/g' .docker/nginx.conf > .docker/nginx.conf.unprivileged


### PR DESCRIPTION
## Description

This PR remove the mainsail.zip file from the /dist directory, before the workflow copy it to the docker image. This will make the Docker image smaller.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
