### PR TITLE
chore(Docker): remove default nginx files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN sed 's/80/8080/g' .docker/nginx.conf > .docker/nginx.conf.unprivileged
 #
 FROM nginxinc/nginx-unprivileged:stable-alpine AS unprivileged
 
+USER root
 RUN rm -rf /usr/share/nginx/html/*
 COPY --link --from=builder /app/.docker/nginx.conf.unprivileged  /etc/nginx/conf.d/default.conf
 COPY --link --from=builder /app/dist/ /usr/share/nginx/html/


### PR DESCRIPTION
## Description

This PR removes the default nginx files, before copying the static mainsail files. There was a 50x.html file for example.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
<img width="1265" height="296" alt="grafik" src="https://github.com/user-attachments/assets/d8dbc24d-3c58-4a23-8d8c-e1a105a08370" />

after:
<img width="1349" height="279" alt="grafik" src="https://github.com/user-attachments/assets/24095a84-47c5-4212-b035-e95c54b91840" />

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
