### PR TITLE
docs: add translated badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,33 @@
   Makes Klipper more accessible by adding a lightweight, responsive web user interface, centred around an intuitive and consistent design philosophy.
 </p>
 <p align="center">
-    <a aria-label="Downloads" href="https://github.com/mainsail-crew/mainsail/releases">
-      <img src="https://img.shields.io/github/downloads/mainsail-crew/mainsail/total?style=flat-square">
+  <a aria-label="Downloads" href="https://github.com/mainsail-crew/mainsail/releases">
+    <img src="https://img.shields.io/github/downloads/mainsail-crew/mainsail/total?style=flat-square">
   </a>
-    <a aria-label="Stars" href="https://github.com/mainsail-crew/mainsail/stargazers">
-      <img src="https://img.shields.io/github/stars/mainsail-crew/mainsail?style=flat-square">
+  <a aria-label="Stars" href="https://github.com/mainsail-crew/mainsail/stargazers">
+    <img src="https://img.shields.io/github/stars/mainsail-crew/mainsail?style=flat-square">
   </a>
-    <a aria-label="Forks" href="https://github.com/mainsail-crew/mainsail/network/members">
-      <img src="https://img.shields.io/github/forks/mainsail-crew/mainsail?style=flat-square">
+  <a aria-label="Forks" href="https://github.com/mainsail-crew/mainsail/network/members">
+    <img src="https://img.shields.io/github/forks/mainsail-crew/mainsail?style=flat-square">
   </a>
-    <a aria-label="License" href="https://github.com/mainsail-crew/mainsail/blob/develop/LICENSE">
-      <img src="https://img.shields.io/github/license/mainsail-crew/mainsail?style=flat-square">
+  <a href="https://hosted.weblate.org/engage/mainsail/">
+    <img src="https://hosted.weblate.org/widget/mainsail/mainsail/svg-badge.svg" alt="Übersetzungsstatus" />
   </a>
-    <a aria-label="Last commit" href="https://github.com/mainsail-crew/mainsail/commits/">
-      <img src="https://img.shields.io/github/last-commit/meteyou/mainsail?style=flat-square">
+  <a aria-label="License" href="https://github.com/mainsail-crew/mainsail/blob/develop/LICENSE">
+    <img src="https://img.shields.io/github/license/mainsail-crew/mainsail?style=flat-square">
   </a>
-<br />
-    <a aria-label="Size" href="https://github.com/mainsail-crew/mainsail/">
-      <img src="https://img.shields.io/github/repo-size/meteyou/mainsail?style=flat-square">
+  <a aria-label="Last commit" href="https://github.com/mainsail-crew/mainsail/commits/">
+    <img src="https://img.shields.io/github/last-commit/meteyou/mainsail?style=flat-square">
   </a>
-    <a aria-label="Discord" href="https://discord.gg/skWTwTD">
-      <img src="https://img.shields.io/discord/758059413700345988?color=%235865F2&label=discord&logo=discord&logoColor=white&style=flat-square">
+  <br />
+  <a aria-label="Size" href="https://github.com/mainsail-crew/mainsail/">
+    <img src="https://img.shields.io/github/repo-size/meteyou/mainsail?style=flat-square">
   </a>
-    <a aria-label="Patreon" href="https://www.patreon.com/meteyou">
-      <img src="https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-patreon.vercel.app%2Fapi%3Fusername%3Dmeteyou%26type%3Dpatrons&style=flat-square">
+  <a aria-label="Discord" href="https://discord.gg/skWTwTD">
+    <img src="https://img.shields.io/discord/758059413700345988?color=%235865F2&label=discord&logo=discord&logoColor=white&style=flat-square">
+  </a>
+  <a aria-label="Patreon" href="https://www.patreon.com/meteyou">
+    <img src="https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-patreon.vercel.app%2Fapi%3Fusername%3Dmeteyou%26type%3Dpatrons&style=flat-square">
   </a>
 </p>
 


### PR DESCRIPTION
## Description

This PR adds a "translated x%" badge to the README.md.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before: 
<img width="890" height="283" alt="grafik" src="https://github.com/user-attachments/assets/2a10cb35-b07e-4ec5-bf08-2c9f341d5ae6" />

after:
<img width="1072" height="271" alt="grafik" src="https://github.com/user-attachments/assets/cea67510-b726-4b28-aa45-3d72f51f7a03" />

## [optional] Are there any post-deployment tasks we need to perform?

none
