### PR TITLE
fix: correct bed mesh coordinate calculation

### DIFF
--- a/src/components/panels/Heightmap/HeightmapCurrentProfilePanel.vue
+++ b/src/components/panels/Heightmap/HeightmapCurrentProfilePanel.vue
@@ -94,7 +94,7 @@ export default class HeightmapCurrentProfilePanel extends Mixins(BaseMixin, Bedm
     }
 
     get index_max_x() {
-        return this.index_max % this.y_count
+        return this.index_max % this.x_count
     }
 
     get position_max_x() {
@@ -114,7 +114,7 @@ export default class HeightmapCurrentProfilePanel extends Mixins(BaseMixin, Bedm
     }
 
     get index_min_x() {
-        return this.index_min % this.y_count
+        return this.index_min % this.x_count
     }
 
     get position_min_x() {


### PR DESCRIPTION
## Description
Current mesh information panel shows the wrong x coordinate for the "Max" and "Min" z offset positions.
Klipper's bed mesh uses row major order.
Column index should always be calculated modulo x count.

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Mobile & Desktop Screenshots/Recordings

No visual changes.

Example of the error:

<img width="1810" height="858" alt="image" src="https://github.com/user-attachments/assets/86d67ef0-142e-4273-9b59-8f7146902f68" />
<img width="1885" height="902" alt="image" src="https://github.com/user-attachments/assets/8031402f-e0ac-4d37-972b-4afd00e30bb5" />



## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
