### PR TITLE
fix(ExtruderPanel): always show pressure advance option in cogs menu

### DIFF
--- a/src/components/panels/Extruder/ExtruderPanelSettings.vue
+++ b/src/components/panels/Extruder/ExtruderPanelSettings.vue
@@ -20,7 +20,7 @@
                     hide-details
                     :label="$t('Panels.ExtruderControlPanel.ExtrusionFactor')" />
             </v-list-item>
-            <v-list-item v-if="existsPressureAdvance" class="minHeight36">
+            <v-list-item class="minHeight36">
                 <v-checkbox
                     v-model="showPressureAdvance"
                     class="mt-0"
@@ -69,10 +69,6 @@ export default class ExtruderPanelSettings extends Mixins(BaseMixin, ControlMixi
 
     set showExtrusionFactor(newVal: boolean) {
         this.$store.dispatch('gui/saveSetting', { name: 'view.extruder.showExtrusionFactor', value: newVal })
-    }
-
-    get existsPressureAdvance(): boolean {
-        return !(this.$store.getters['printer/getExtruderSteppers'].length > 0)
     }
 
     get showPressureAdvance(): boolean {


### PR DESCRIPTION
## Description

This PR fix an issue in the Extruder Panel and extruder_steppers. This PR will show the option "Pressure Advance" always in the cogs menu from the Extruder Panel.

## Related Tickets & Documents

- Post with the issue: https://github.com/mainsail-crew/mainsail/pull/2283#issuecomment-3589753060

## Mobile & Desktop Screenshots/Recordings

<img width="621" height="437" alt="grafik" src="https://github.com/user-attachments/assets/6801bece-3b10-4cb8-aa40-0d3e7e0586a6" />

## [optional] Are there any post-deployment tasks we need to perform?

none
