### PR TITLE
fix: Happy Hare - Context Menu for gates

### DIFF
--- a/src/assets/styles/page.css
+++ b/src/assets/styles/page.css
@@ -47,6 +47,9 @@ body {
 .h-100 {
     height: 100% !important;
 }
+.h-auto {
+    height: auto !important;
+}
 
 .position-absolute {
     position: absolute !important;

--- a/src/components/panels/Mmu/MmuUnit.vue
+++ b/src/components/panels/Mmu/MmuUnit.vue
@@ -7,6 +7,7 @@
                 :gate-index="gateIndex - 1 + firstGateNumber"
                 :mmu-machine-unit="mmuMachineUnit"
                 :show-details="showDetails"
+                :show-context-menu="showContextMenu"
                 :unhighlight-spools="unhighlightSpools"
                 :selected-gate="selectedGate"
                 @select-gate="selectGate" />
@@ -14,6 +15,7 @@
                 v-if="hasBypass"
                 :gate-index="TOOL_GATE_BYPASS"
                 :mmu-machine-unit="mmuMachineUnit"
+                :show-context-menu="false"
                 :selected-gate="selectedGate"
                 @select-gate="selectGate" />
         </div>
@@ -35,6 +37,7 @@ export default class MmuUnit extends Mixins(BaseMixin, MmuMixin) {
     @Prop({ required: true }) readonly selectedGate!: number
     @Prop({ required: true }) readonly unitIndex!: number
     @Prop({ default: false }) readonly showDetails!: boolean
+    @Prop({ default: false }) readonly showContextMenu!: boolean
     @Prop({ default: false }) readonly hideBypass!: boolean
     @Prop({ default: false }) readonly unhighlightSpools!: boolean
 

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -1,34 +1,129 @@
 <template>
     <div class="d-flex flex-column align-center">
-        <mmu-unit-gate-spool
-            class="position-relative zindex-1"
-            :gate-index="gateIndex"
-            :show-details="showDetails"
-            :is-selected="isSelected"
-            :unhighlight-spools="unhighlightSpools"
-            @select-gate="selectGate" />
+        <!-- Important context menu -->
+        <v-menu
+            v-model="contextMenu"
+            transition="slide-y-transition"
+            :position-x="menuX"
+            :position-y="menuY"
+            :close-on-content-click="false"
+            :open-on-click="false"
+            absolute
+            offset-y
+        >
+            <template #activator="{ attrs }">
+                <div
+                    class="d-flex"
+                    v-bind="attrs"
+                    @contextmenu.prevent.stop="openContextMenu"
+                    @pointerdown="onPointerDown"
+                    @pointerup="onPointerUp"
+                    @pointercancel="onPointerUp"
+                    @pointerleave="onPointerUp"
+                >
+                    <mmu-unit-gate-spool
+                        class="position-relative zindex-1"
+                        :gate-index="gateIndex"
+                        :show-details="showDetails"
+                        :is-selected="isSelected"
+                        :unhighlight-spools="unhighlightSpools"
+                        @select-gate="selectGate"
+                    />
+                </div>
+            </template>
 
-        <span class="gate-number rounded cursor-pointer" :class="gateNumberClass" @click="selectGate">
+            <v-list dense @mouseleave="closeContextMenu">
+                <v-subheader class="compact-subheader">Gate {{ gateIndex }}</v-subheader>
+                <v-divider />
+                <v-list-item>
+                    <v-btn
+                        small
+                        style="width: 100%"
+                        :disabled="!canSend"
+                        :loading="loadings.includes('mmu_select')"
+                        @click="gateCommand('MMU_SELECT')"
+                    >
+                        <v-icon left>
+                            {{ mdiSwapHorizontal }}
+                        </v-icon>
+                        {{ $t('Panels.MmuPanel.ButtonSelect') }}
+                    </v-btn>
+                </v-list-item>
+                <v-list-item>
+                    <v-btn
+                        small
+                        style="width: 100%"
+                        :disabled="!canSend"
+                        :loading="loadings.includes('mmu_preload')"
+                        @click="gateCommand('MMU_PRELOAD')"
+                    >
+                        <v-icon left>
+                            {{ mdiDownloadOutline }}
+                        </v-icon>
+                        {{ $t('Panels.MmuPanel.ButtonPreload') }}
+                    </v-btn>
+                </v-list-item>
+                <v-list-item>
+                    <v-btn
+                        small
+                        style="width: 100%"
+                        :disabled="!canSend"
+                        :loading="loadings.includes('mmu_eject')"
+                        @click="gateCommand('MMU_EJECT')"
+                    >
+                        <v-icon left>
+                            {{ mdiEject }}
+                        </v-icon>
+                        {{ $t('Panels.MmuPanel.ButtonEject') }}
+                    </v-btn>
+                </v-list-item>
+            </v-list>
+        </v-menu>
+
+        <span
+            class="gate-number rounded cursor-pointer"
+            :class="gateNumberClass"
+            @click="selectGate"
+        >
             {{ gateName }}
         </span>
     </div>
 </template>
+
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import MmuMixin, { MmuMachineUnit, TOOL_GATE_BYPASS } from '@/components/mixins/mmu'
+import { mdiSwapHorizontal, mdiDownloadOutline, mdiEject } from '@mdi/js'
 
 @Component
 export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
+    mdiSwapHorizontal = mdiSwapHorizontal
+    mdiDownloadOutline = mdiDownloadOutline
+    mdiEject = mdiEject
+
     @Prop({ required: true }) readonly gateIndex!: number
     @Prop({ required: true }) readonly mmuMachineUnit!: MmuMachineUnit
     @Prop({ default: false }) readonly showDetails!: boolean
+    @Prop({ default: false }) readonly showContextMenu!: boolean
     @Prop({ required: true }) readonly selectedGate!: number
     @Prop({ default: false }) readonly unhighlightSpools!: boolean
 
+    closeTimeout: number | null = null
+    contextMenu = false
+    menuX = 0
+    menuY = 0
+
+    // Long-press state
+    longPressTimeout: number | null = null
+    longPressDuration = 500
+    isPressing = false
+    pressStartX = 0
+    pressStartY = 0
+
+
     get gateName() {
         if (this.gateIndex === TOOL_GATE_BYPASS) return 'Bypass'
-
         return this.gateIndex
     }
 
@@ -51,6 +146,89 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
 
     selectGate() {
         this.$emit('select-gate', this.gateIndex)
+    }
+
+    openContextMenu(e: MouseEvent) {
+        e.preventDefault()
+        this.openContextMenuAt(e.clientX, e.clientY)
+    }
+
+    openContextMenuAt(clientX: number, clientY: number) {
+        if (this.gateIndex < 0 || this.gateIndex === this.selectedGate || !this.showContextMenu) return
+
+        this.menuX = clientX - 20
+        this.menuY = clientY - 20
+
+        this.closeContextMenu()
+
+        this.contextMenu = true
+        this.closeTimeout = setTimeout(() => {
+            this.closeContextMenu()
+        }, 6000)
+    }
+
+    closeContextMenu() {
+        if (this.closeTimeout) {
+            clearTimeout(this.closeTimeout)
+        }
+        this.closeTimeout = null
+        this.contextMenu = false
+    }
+
+    onPointerDown(e: PointerEvent) {
+        if (this.gateIndex < 0 || this.gateIndex === this.selectedGate || !this.showContextMenu) return
+
+        dispatchEvent(new CustomEvent('mmu-close-all-menus'))
+
+        this.isPressing = true
+        this.pressStartX = e.clientX
+        this.pressStartY = e.clientY
+
+        this.clearLongPressTimeout()
+        this.longPressTimeout = setTimeout(() => {
+            if (this.isPressing) {
+                this.openContextMenuAt(this.pressStartX, this.pressStartY)
+            }
+            this.clearPressState()
+        }, this.longPressDuration)
+    }
+
+    onPointerUp() {
+        this.clearPressState()
+    }
+
+    clearPressState() {
+        this.isPressing = false
+        this.clearLongPressTimeout()
+    }
+
+    clearLongPressTimeout() {
+        if (this.longPressTimeout) {
+            clearTimeout(this.longPressTimeout)
+        }
+        this.longPressTimeout = null
+    }
+
+    mounted() {
+        addEventListener('mmu-close-all-menus', this.onGlobalCloseMenus)
+    }
+
+    beforeDestroy() {
+        removeEventListener('mmu-close-all-menus', this.onGlobalCloseMenus)
+
+        this.closeContextMenu()
+        this.clearLongPressTimeout()
+        this.isPressing = false
+    }
+
+    onGlobalCloseMenus = () => {
+        this.closeContextMenu()
+    }
+
+    gateCommand(command: string) {
+        const fullGcode = `${command} GATE=${this.gateIndex}`
+        const loading = command.toLowerCase()
+        this.doSend(fullGcode, loading)
     }
 }
 </script>
@@ -94,5 +272,13 @@ html.theme--light .gate-number {
 
 .gate-number.border-unknown {
     border-color: orange;
+}
+
+.v-list--dense .compact-subheader {
+    height: auto;
+    padding-bottom: 6px;
+    display: block;
+    font-size: 14px;
+    text-align: center;
 }
 </style>

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -9,8 +9,7 @@
             :close-on-content-click="false"
             :open-on-click="false"
             absolute
-            offset-y
-        >
+            offset-y>
             <template #activator="{ attrs }">
                 <div
                     class="d-flex"
@@ -19,16 +18,14 @@
                     @pointerdown="onPointerDown"
                     @pointerup="onPointerUp"
                     @pointercancel="onPointerUp"
-                    @pointerleave="onPointerUp"
-                >
+                    @pointerleave="onPointerUp">
                     <mmu-unit-gate-spool
                         class="position-relative zindex-1"
                         :gate-index="gateIndex"
                         :show-details="showDetails"
                         :is-selected="isSelected"
                         :unhighlight-spools="unhighlightSpools"
-                        @select-gate="selectGate"
-                    />
+                        @select-gate="selectGate" />
                 </div>
             </template>
 
@@ -41,8 +38,7 @@
                         style="width: 100%"
                         :disabled="!canSend"
                         :loading="loadings.includes('mmu_select')"
-                        @click="gateCommand('MMU_SELECT')"
-                    >
+                        @click="gateCommand('MMU_SELECT')">
                         <v-icon left>
                             {{ mdiSwapHorizontal }}
                         </v-icon>
@@ -55,8 +51,7 @@
                         style="width: 100%"
                         :disabled="!canSend"
                         :loading="loadings.includes('mmu_preload')"
-                        @click="gateCommand('MMU_PRELOAD')"
-                    >
+                        @click="gateCommand('MMU_PRELOAD')">
                         <v-icon left>
                             {{ mdiDownloadOutline }}
                         </v-icon>
@@ -69,8 +64,7 @@
                         style="width: 100%"
                         :disabled="!canSend"
                         :loading="loadings.includes('mmu_eject')"
-                        @click="gateCommand('MMU_EJECT')"
-                    >
+                        @click="gateCommand('MMU_EJECT')">
                         <v-icon left>
                             {{ mdiEject }}
                         </v-icon>
@@ -80,11 +74,7 @@
             </v-list>
         </v-menu>
 
-        <span
-            class="gate-number rounded cursor-pointer"
-            :class="gateNumberClass"
-            @click="selectGate"
-        >
+        <span class="gate-number rounded cursor-pointer" :class="gateNumberClass" @click="selectGate">
             {{ gateName }}
         </span>
     </div>
@@ -120,7 +110,6 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     isPressing = false
     pressStartX = 0
     pressStartY = 0
-
 
     get gateName() {
         if (this.gateIndex === TOOL_GATE_BYPASS) return 'Bypass'

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -86,7 +86,7 @@
                     <div class="text-center body-1">{{ statusText }}</div>
                     <mmu-filament-status />
                     <div v-if="showClogDetection" class="text-center">
-                        <mmu-clog-meter v-if="hasMmuEncoder" width="40%" />
+                        <mmu-clog-meter width="40%" />
                         <div class="text--disabled body-1">{{ $t('Panels.MmuPanel.ClogDetection') }}</div>
                     </div>
                 </v-col>

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -86,7 +86,7 @@
                     <div class="text-center body-1">{{ statusText }}</div>
                     <mmu-filament-status />
                     <div v-if="showClogDetection" class="text-center">
-                        <mmu-clog-meter width="40%" />
+                        <mmu-clog-meter v-if="hasMmuEncoder" width="40%" />
                         <div class="text--disabled body-1">{{ $t('Panels.MmuPanel.ClogDetection') }}</div>
                     </div>
                 </v-col>

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -76,6 +76,7 @@
                         :selected-gate="mmuGate"
                         :unit-index="i - 1"
                         :show-details="true"
+                        :show-context-menu="true"
                         @select-gate="selectGate" />
                 </v-col>
             </v-row>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -806,6 +806,7 @@
             "EditTtgMapTitle": "Map Tools / Filaments (Edit TTG Map)",
             "Encoder": "Encoder",
             "Extruder": "Extruder",
+            "Gate": "Gate",
             "GateMapDialog": {
                 "BadTemperature": "Temperature out of range",
                 "ChooseSpool": "Choose Spool",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -788,6 +788,7 @@
             "ButtonPreload": "Preload",
             "ButtonPrintStats": "Print Stats",
             "ButtonRecover": "Recover",
+            "ButtonSelect": "Select",
             "ButtonSyncSpoolman": "Sync Spoolman",
             "ButtonUnload": "Unload",
             "ButtonUnloadExt": "Unload Ext",


### PR DESCRIPTION
## Description
Added important functionality that was missed in merge/rework.
Specifically the addition on context sensitive menus to gates.  This is implemented with "right-click" for desktop as well as "long-click" for mobile.
It is required to be able to operation on non-selected gate. Notable example is ejecting filament from the non-current (loaded) gate.

## Related Tickets & Documents
Ticket in Happy Hare forum

## Mobile & Desktop Screenshots/Recordings
<img width="451" height="258" alt="Screenshot 2025-12-05 at 10 40 52 AM" src="https://github.com/user-attachments/assets/5b00c450-7b0e-4fc9-8a71-097a1b46430c" />


## [optional] Are there any post-deployment tasks we need to perform?
CTRL-Click the non selected gate for context specific operations menu.

Signed off by: Paul Morgan <moggieuk@hotmail.com>
