### PR TITLE
feat(HappyHare): add Flowguard meter to monitor clog/tangle

### DIFF
--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -70,8 +70,19 @@ export interface Mmu {
         | typeof ACTION_PURGING
     has_bypass: boolean
     sync_drive: boolean
+    sync_feedback_bias_modelled: number
+    sync_feedback_bias_raw: number
     sync_feedback_enabled: boolean
     sync_feedback_state: string
+    flowguard?: {
+        trigger: string
+        reason: string
+        level: number
+        max_clog: number
+        max_tangle: number
+        active: boolean
+        enabled: boolean
+    }
     clog_detection: number
     clog_detection_enabled: number
     endless_spool: number

--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -70,8 +70,6 @@ export interface Mmu {
         | typeof ACTION_PURGING
     has_bypass: boolean
     sync_drive: boolean
-    sync_feedback_bias_modelled: number
-    sync_feedback_bias_raw: number
     sync_feedback_enabled: boolean
     sync_feedback_state: string
     flowguard?: {

--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -210,6 +210,22 @@ export default class MmuMixin extends Mixins(BaseMixin) {
         return 'encoder' in (this.mmu ?? {})
     }
 
+    get hasFilamentProportionalSensor() {
+        return this.hasMmuSensor('filament_proportional')
+    }
+
+    get hasFilamentCompressionSensor() {
+        return this.hasMmuSensor('filament_compression')
+    }
+
+    get hasFilamentTensionSensor() {
+        return this.hasMmuSensor('filament_tension')
+    }
+
+    get hasSyncFeedback(): boolean {
+        return this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
+    }
+
     get mmuMachine(): MmuMachine | undefined {
         return this.$store.state.printer.mmu_machine ?? undefined
     }

--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -35,10 +35,6 @@ import MmuMixin, { FILAMENT_POS_END_BOWDEN } from '@/components/mixins/mmu'
 
 @Component
 export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, MmuMixin) {
-    get hasSyncFeedback(): boolean {
-        return this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
-    }
-
     get syncFeedbackActive(): boolean {
         const enabled = this.mmu?.sync_feedback_enabled ?? false
         const loaded = this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
@@ -51,18 +47,6 @@ export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, Mmu
 
     get syncFeedbackPistonPos(): number {
         return this.syncFeedbackBiasModelled * 12 + 234
-    }
-
-    get hasFilamentProportionalSensor() {
-        return this.hasMmuSensor('filament_proportional')
-    }
-
-    get hasFilamentCompressionSensor() {
-        return this.hasMmuSensor('filament_compression')
-    }
-
-    get hasFilamentTensionSensor() {
-        return this.hasMmuSensor('filament_tension')
     }
 }
 </script>

--- a/src/components/panels/Mmu/MmuFlowguardMeter.vue
+++ b/src/components/panels/Mmu/MmuFlowguardMeter.vue
@@ -97,8 +97,12 @@
             stroke-dashoffset="0"
             stroke-dasharray="18,63" />
 
-        <text x="70" y="58" text-anchor="middle" class="small-text-color" font-size="12px">{{ $t('Panels.MmuPanel.Flow') }}</text>
-        <text x="70" y="72" text-anchor="middle" class="small-text-color" font-size="12px">{{ $t('Panels.MmuPanel.Guard') }}</text>
+        <text x="70" y="58" text-anchor="middle" class="small-text-color" font-size="12px">
+            {{ $t('Panels.MmuPanel.Flow') }}
+        </text>
+        <text x="70" y="72" text-anchor="middle" class="small-text-color" font-size="12px">
+            {{ $t('Panels.MmuPanel.Guard') }}
+        </text>
         <text
             v-if="flowguardActive && !flowguardTrigger"
             x="70"
@@ -112,7 +116,9 @@
         <text v-if="flowguardTrigger" x="70" y="90" text-anchor="middle" class="small-text-warning" font-size="16px">
             {{ flowguardTrigger }}
         </text>
-        <text x="58" y="139" text-anchor="end" class="small-text-color" font-size="12px">{{ $t('Panels.MmuPanel.Tangle') }}</text>
+        <text x="58" y="139" text-anchor="end" class="small-text-color" font-size="12px">
+            {{ $t('Panels.MmuPanel.Tangle') }}
+        </text>
         <text x="86" y="139" class="small-text-color" font-size="12px">{{ $t('Panels.MmuPanel.Clog') }}</text>
     </svg>
 </template>

--- a/src/components/panels/Mmu/MmuFlowguardMeter.vue
+++ b/src/components/panels/Mmu/MmuFlowguardMeter.vue
@@ -97,8 +97,8 @@
             stroke-dashoffset="0"
             stroke-dasharray="18,63" />
 
-        <text x="70" y="58" text-anchor="middle" class="small-text-color" font-size="12px">FLOW</text>
-        <text x="70" y="72" text-anchor="middle" class="small-text-color" font-size="12px">GUARD</text>
+        <text x="70" y="58" text-anchor="middle" class="small-text-color" font-size="12px">{{ $t('Panels.MmuPanel.Flow') }}</text>
+        <text x="70" y="72" text-anchor="middle" class="small-text-color" font-size="12px">{{ $t('Panels.MmuPanel.Guard') }}</text>
         <text
             v-if="flowguardActive && !flowguardTrigger"
             x="70"
@@ -107,13 +107,13 @@
             class="small-text-color"
             font-size="12px"
             font-weight="bold">
-            ACTIVE
+            {{ $t('Panels.MmuPanel.Active') }}
         </text>
         <text v-if="flowguardTrigger" x="70" y="90" text-anchor="middle" class="small-text-warning" font-size="16px">
             {{ flowguardTrigger }}
         </text>
-        <text x="58" y="139" text-anchor="end" class="small-text-color" font-size="12px">TANGLE</text>
-        <text x="86" y="139" class="small-text-color" font-size="12px">CLOG</text>
+        <text x="58" y="139" text-anchor="end" class="small-text-color" font-size="12px">{{ $t('Panels.MmuPanel.Tangle') }}</text>
+        <text x="86" y="139" class="small-text-color" font-size="12px">{{ $t('Panels.MmuPanel.Clog') }}</text>
     </svg>
 </template>
 

--- a/src/components/panels/Mmu/MmuFlowguardMeter.vue
+++ b/src/components/panels/Mmu/MmuFlowguardMeter.vue
@@ -1,0 +1,267 @@
+<template>
+    <svg ref="flowguardMeter" viewBox="0 0 140 140" preserveAspectRatio="xMidYMid meet" :class="svgClasses">
+        <g transform="rotate(120 70 70)">
+            <circle
+                cx="70"
+                cy="70"
+                r="50"
+                class="v-progress-circular__underlay"
+                fill="transparent"
+                stroke-width="18"
+                :stroke-dasharray="CIRCUMFERENCE"
+                :stroke-dashoffset="DIAL_ARC" />
+        </g>
+        <g transform="rotate(270 70 70)">
+            <circle
+                ref="dialCircle"
+                cx="70"
+                cy="70"
+                r="50"
+                class="primary-color"
+                fill="transparent"
+                stroke-width="18"
+                :stroke-dasharray="CIRCUMFERENCE"
+                :stroke-dashoffset="meterDashOffset" />
+        </g>
+        <g transform="rotate(60 70 70)">
+            <circle
+                cx="70"
+                cy="70"
+                r="50"
+                class="warning-color"
+                fill="transparent"
+                stroke-width="18"
+                opacity="0.3"
+                :stroke-dasharray="CIRCUMFERENCE"
+                :stroke-dashoffset="clogHeadroomDashOffset" />
+        </g>
+        <g transform="rotate(120 70 70)">
+            <circle
+                cx="70"
+                cy="70"
+                r="50"
+                class="warning-color"
+                fill="transparent"
+                stroke-width="18"
+                opacity="0.3"
+                :stroke-dasharray="CIRCUMFERENCE"
+                :stroke-dashoffset="tangleHeadroomDashOffset" />
+        </g>
+        <line
+            ref="minHeadroomLine"
+            :x1="x1MaxClog"
+            :y1="y1MaxClog"
+            x2="70"
+            y2="70"
+            style="opacity: 0.6"
+            :class="maxClogLineClasses"
+            stroke-width="2"
+            stroke-dashoffset="0"
+            stroke-dasharray="18,63" />
+        <line
+            ref="minHeadroomLine"
+            :x1="x1MaxTangle"
+            :y1="y1MaxTangle"
+            x2="70"
+            y2="70"
+            style="opacity: 0.6"
+            :class="maxTangleLineClasses"
+            stroke-width="2"
+            stroke-dashoffset="0"
+            stroke-dasharray="18,63" />
+        <line
+            :x1="X1_TANGLE"
+            :y1="Y1_TANGLE"
+            x2="70"
+            y2="70"
+            class="warning-color"
+            stroke-width="2"
+            stroke-dashoffset="0"
+            stroke-dasharray="22,63" />
+        <line
+            :x1="X1_CLOG"
+            :y1="Y1_CLOG"
+            x2="70"
+            y2="70"
+            class="warning-color"
+            stroke-width="2"
+            stroke-dashoffset="0"
+            stroke-dasharray="22,63" />
+        <line
+            :x1="X1_ZERO"
+            :y1="Y1_ZERO"
+            x2="70"
+            y2="70"
+            stroke="white"
+            stroke-width="2"
+            stroke-dashoffset="0"
+            stroke-dasharray="18,63" />
+
+        <text x="70" y="58" text-anchor="middle" class="small-text-color" font-size="12px">FLOW</text>
+        <text x="70" y="72" text-anchor="middle" class="small-text-color" font-size="12px">GUARD</text>
+        <text
+            v-if="flowguardActive && !flowguardTrigger"
+            x="70"
+            y="90"
+            text-anchor="middle"
+            class="small-text-color"
+            font-size="12px"
+            font-weight="bold">
+            ACTIVE
+        </text>
+        <text v-if="flowguardTrigger" x="70" y="90" text-anchor="middle" class="small-text-warning" font-size="16px">
+            {{ flowguardTrigger }}
+        </text>
+        <text x="58" y="139" text-anchor="end" class="small-text-color" font-size="12px">TANGLE</text>
+        <text x="86" y="139" class="small-text-color" font-size="12px">CLOG</text>
+    </svg>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Ref, Watch } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import MmuMixin, { DIRECTION_UNKNOWN } from '@/components/mixins/mmu'
+
+@Component
+export default class MmuFlowguardMeter extends Mixins(BaseMixin, MmuMixin) {
+    @Ref('dialCircle') dialCircle!: SVGCircleElement
+
+    ROTATION_TIME = 1
+    CIRCUMFERENCE = 2 * Math.PI * 50
+    DIAL_ARC = this.CIRCUMFERENCE * (60 / 360)
+    X1_TANGLE = 70 + 63 * Math.cos((120 * Math.PI) / 180)
+    Y1_TANGLE = 70 + 63 * Math.sin((120 * Math.PI) / 180)
+    X1_CLOG = 70 + 63 * Math.cos((60 * Math.PI) / 180)
+    Y1_CLOG = 70 + 63 * Math.sin((60 * Math.PI) / 180)
+    X1_ZERO = 70 + 59 * Math.cos((270 * Math.PI) / 180)
+    Y1_ZERO = 70 + 59 * Math.sin((270 * Math.PI) / 180)
+    DANGER = 0.8
+
+    get flowguardEnabled() {
+        return this.mmu?.flowguard?.enabled ?? false
+    }
+
+    get flowguardActive() {
+        return this.mmu?.flowguard?.active ?? false
+    }
+
+    get flowguardTrigger() {
+        return (this.mmu?.flowguard?.trigger ?? '').toUpperCase()
+    }
+
+    get maxClog() {
+        return Math.abs(this.mmu?.flowguard?.max_clog ?? 0.0)
+    }
+
+    get maxTangle() {
+        return -Math.abs(this.mmu?.flowguard?.max_tangle ?? 0.0)
+    }
+
+    get flowguardLevel() {
+        return this.mmu?.flowguard?.level ?? 0.0
+    }
+
+    get svgClasses() {
+        return { 'disabled-flowguard': !this.flowguardEnabled }
+    }
+
+    get clogWarning() {
+        return Math.abs(this.maxClog) > this.DANGER
+    }
+
+    get maxClogLineClasses() {
+        return {
+            'warning-color': this.clogWarning,
+            'primary-color': !this.clogWarning,
+        }
+    }
+
+    get clogHeadroomDashOffset() {
+        return this.CIRCUMFERENCE * (1 + (1 - this.DANGER) * (150 / 360))
+    }
+
+    get tangleWarning() {
+        return Math.abs(this.maxTangle) > this.DANGER
+    }
+
+    get maxTangleLineClasses() {
+        return {
+            'warning-color': this.tangleWarning,
+            'primary-color': !this.tangleWarning,
+        }
+    }
+
+    get tangleHeadroomDashOffset() {
+        return this.CIRCUMFERENCE * (1 - (1 - this.DANGER) * (150 / 360))
+    }
+
+    get flowguardPercent() {
+        return Math.max(Math.min(1, this.flowguardLevel), -1) * 100
+    }
+
+    get meterDashOffset() {
+        return this.CIRCUMFERENCE * ((100 - (this.flowguardPercent * 150) / 360) / 100)
+    }
+
+    get maxClogAngle() {
+        return this.maxClog * 150 + 150
+    }
+
+    get x1MaxClog() {
+        return this.calcX1(this.maxClogAngle)
+    }
+
+    get y1MaxClog() {
+        return this.calcY1(this.maxClogAngle)
+    }
+
+    get maxTangleAngle() {
+        return this.maxTangle * 150 + 150
+    }
+
+    get x1MaxTangle() {
+        return this.calcX1(this.maxTangleAngle)
+    }
+
+    get y1MaxTangle() {
+        return this.calcY1(this.maxTangleAngle)
+    }
+
+    private calcX1(angle: number) {
+        return 70 + 59 * Math.cos(((120 + angle) * Math.PI) / 180)
+    }
+
+    private calcY1(angle: number) {
+        return 70 + 59 * Math.sin(((120 + angle) * Math.PI) / 180)
+    }
+
+    @Watch('meterDashOffset', { immediate: true })
+    onDashOffsetChanged(newValue: number) {
+        if (!this.dialCircle) return
+
+        const currentOffset = parseFloat(this.dialCircle?.style?.strokeDashoffset) || this.CIRCUMFERENCE
+        const difference = Math.abs(currentOffset - newValue)
+        const duration = (difference / this.CIRCUMFERENCE) * this.ROTATION_TIME
+        this.dialCircle.style.transition = `stroke-dashoffset ${duration}s ease-out`
+    }
+}
+</script>
+
+<style scoped>
+.disabled-flowguard {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+.primary-color {
+    stroke: var(--v-primary-lighten1, #2ca9bc);
+}
+.warning-color {
+    stroke: var(--v-error-base, #ff0000);
+}
+.small-text-color {
+    fill: var(--v-primary-lighten1, #2ca9bc);
+}
+.small-text-warning {
+    fill: var(--v-error-base, #ff0000);
+}
+</style>

--- a/src/components/panels/Mmu/MmuFlowguardMeter.vue
+++ b/src/components/panels/Mmu/MmuFlowguardMeter.vue
@@ -98,10 +98,10 @@
             stroke-dasharray="18,63" />
 
         <text x="70" y="58" text-anchor="middle" class="small-text-color" font-size="12px">
-            {{ $t('Panels.MmuPanel.Flow') }}
+            {{ flowTextUpper }}
         </text>
         <text x="70" y="72" text-anchor="middle" class="small-text-color" font-size="12px">
-            {{ $t('Panels.MmuPanel.Guard') }}
+            {{ guardTextUpper }}
         </text>
         <text
             v-if="flowguardActive && !flowguardTrigger"
@@ -111,15 +111,17 @@
             class="small-text-color"
             font-size="12px"
             font-weight="bold">
-            {{ $t('Panels.MmuPanel.Active') }}
+            {{ activeTextUpper }}
         </text>
         <text v-if="flowguardTrigger" x="70" y="90" text-anchor="middle" class="small-text-warning" font-size="16px">
             {{ flowguardTrigger }}
         </text>
         <text x="58" y="139" text-anchor="end" class="small-text-color" font-size="12px">
-            {{ $t('Panels.MmuPanel.Tangle') }}
+            {{ tangleTextUpper }}
         </text>
-        <text x="86" y="139" class="small-text-color" font-size="12px">{{ $t('Panels.MmuPanel.Clog') }}</text>
+        <text x="86" y="139" class="small-text-color" font-size="12px">
+            {{ clogTextUpper }}
+        </text>
     </svg>
 </template>
 
@@ -144,19 +146,23 @@ export default class MmuFlowguardMeter extends Mixins(BaseMixin, MmuMixin) {
     DANGER = 0.8
 
     get tangleTextUpper() {
-        return $t('Panels.MmuPanel.Tangle').toUpperCase()
+        return this.$t('Panels.MmuPanel.Tangle').toUpperCase()
     }
 
     get clogTextUpper() {
-        return $t('Panels.MmuPanel.Clog').toUpperCase()
+        return this.$t('Panels.MmuPanel.Clog').toUpperCase()
     }
 
     get flowTextUpper() {
-        return $t('Panels.MmuPanel.Flow').toUpperCase()
+        return this.$t('Panels.MmuPanel.Flow').toUpperCase()
     }
 
     get guardTextUpper() {
-        return $t('Panels.MmuPanel.Guard').toUpperCase()
+        return this.$t('Panels.MmuPanel.Guard').toUpperCase()
+    }
+
+    get activeTextUpper() {
+        return this.$t('Panels.MmuPanel.Active').toUpperCase()
     }
 
     get flowguardEnabled() {

--- a/src/components/panels/Mmu/MmuFlowguardMeter.vue
+++ b/src/components/panels/Mmu/MmuFlowguardMeter.vue
@@ -120,7 +120,7 @@
 <script lang="ts">
 import { Component, Mixins, Ref, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import MmuMixin, { DIRECTION_UNKNOWN } from '@/components/mixins/mmu'
+import MmuMixin from '@/components/mixins/mmu'
 
 @Component
 export default class MmuFlowguardMeter extends Mixins(BaseMixin, MmuMixin) {

--- a/src/components/panels/Mmu/MmuFlowguardMeter.vue
+++ b/src/components/panels/Mmu/MmuFlowguardMeter.vue
@@ -143,6 +143,22 @@ export default class MmuFlowguardMeter extends Mixins(BaseMixin, MmuMixin) {
     Y1_ZERO = 70 + 59 * Math.sin((270 * Math.PI) / 180)
     DANGER = 0.8
 
+    get tangleTextUpper() {
+        return $t('Panels.MmuPanel.Tangle').toUpperCase()
+    }
+
+    get clogTextUpper() {
+        return $t('Panels.MmuPanel.Clog').toUpperCase()
+    }
+
+    get flowTextUpper() {
+        return $t('Panels.MmuPanel.Flow').toUpperCase()
+    }
+
+    get guardTextUpper() {
+        return $t('Panels.MmuPanel.Guard').toUpperCase()
+    }
+
     get flowguardEnabled() {
         return this.mmu?.flowguard?.enabled ?? false
     }

--- a/src/components/panels/Mmu/MmuFlowguardMeter.vue
+++ b/src/components/panels/Mmu/MmuFlowguardMeter.vue
@@ -98,10 +98,10 @@
             stroke-dasharray="18,63" />
 
         <text x="70" y="58" text-anchor="middle" class="small-text-color" font-size="12px">
-            {{ flowTextUpper }}
+            {{ $t('Panels.MmuPanel.Flow').toUpperCase() }}
         </text>
         <text x="70" y="72" text-anchor="middle" class="small-text-color" font-size="12px">
-            {{ guardTextUpper }}
+            {{ $t('Panels.MmuPanel.Guard').toUpperCase() }}
         </text>
         <text
             v-if="flowguardActive && !flowguardTrigger"
@@ -111,16 +111,16 @@
             class="small-text-color"
             font-size="12px"
             font-weight="bold">
-            {{ activeTextUpper }}
+            {{ $t('Panels.MmuPanel.Active').toUpperCase() }}
         </text>
         <text v-if="flowguardTrigger" x="70" y="90" text-anchor="middle" class="small-text-warning" font-size="16px">
             {{ flowguardTrigger }}
         </text>
         <text x="58" y="139" text-anchor="end" class="small-text-color" font-size="12px">
-            {{ tangleTextUpper }}
+            {{ $t('Panels.MmuPanel.Tangle').toUpperCase() }}
         </text>
         <text x="86" y="139" class="small-text-color" font-size="12px">
-            {{ clogTextUpper }}
+            {{ $t('Panels.MmuPanel.Clog').toUpperCase() }}
         </text>
     </svg>
 </template>
@@ -144,26 +144,6 @@ export default class MmuFlowguardMeter extends Mixins(BaseMixin, MmuMixin) {
     X1_ZERO = 70 + 59 * Math.cos((270 * Math.PI) / 180)
     Y1_ZERO = 70 + 59 * Math.sin((270 * Math.PI) / 180)
     DANGER = 0.8
-
-    get tangleTextUpper() {
-        return this.$t('Panels.MmuPanel.Tangle').toUpperCase()
-    }
-
-    get clogTextUpper() {
-        return this.$t('Panels.MmuPanel.Clog').toUpperCase()
-    }
-
-    get flowTextUpper() {
-        return this.$t('Panels.MmuPanel.Flow').toUpperCase()
-    }
-
-    get guardTextUpper() {
-        return this.$t('Panels.MmuPanel.Guard').toUpperCase()
-    }
-
-    get activeTextUpper() {
-        return this.$t('Panels.MmuPanel.Active').toUpperCase()
-    }
 
     get flowguardEnabled() {
         return this.mmu?.flowguard?.enabled ?? false

--- a/src/components/panels/Mmu/MmuFlowguardMeter.vue
+++ b/src/components/panels/Mmu/MmuFlowguardMeter.vue
@@ -48,7 +48,6 @@
                 :stroke-dashoffset="tangleHeadroomDashOffset" />
         </g>
         <line
-            ref="minHeadroomLine"
             :x1="x1MaxClog"
             :y1="y1MaxClog"
             x2="70"
@@ -59,7 +58,6 @@
             stroke-dashoffset="0"
             stroke-dasharray="18,63" />
         <line
-            ref="minHeadroomLine"
             :x1="x1MaxTangle"
             :y1="y1MaxTangle"
             x2="70"

--- a/src/components/panels/Mmu/MmuPanelSettings.vue
+++ b/src/components/panels/Mmu/MmuPanelSettings.vue
@@ -6,7 +6,7 @@
             </v-btn>
         </template>
         <v-list>
-            <v-list-item v-if="hasMmuEncoder" class="minHeight36">
+            <v-list-item v-if="hasMmuEncoder || hasSyncFeedback" class="minHeight36">
                 <v-checkbox
                     v-model="showClogDetection"
                     class="mt-0"

--- a/src/components/panels/Mmu/MmuPanelSettings.vue
+++ b/src/components/panels/Mmu/MmuPanelSettings.vue
@@ -11,7 +11,7 @@
                     v-model="showClogDetection"
                     class="mt-0"
                     hide-details
-                    :label="$t('Panels.MmuPanel.ShowClogDetection')" />
+                    :label="$t('Panels.MmuPanel.ShowClogTangleDetection')" />
             </v-list-item>
             <v-list-item class="minHeight36">
                 <v-checkbox v-model="showTtgMap" class="mt-0" hide-details :label="$t('Panels.MmuPanel.ShowTtgMap')" />

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -88,7 +88,7 @@
                     <div v-if="showClogDetection" class="text-center">
                         <mmu-clog-meter v-if="hasMmuEncoder" width="40%" />
                         <mmu-flowguard-meter v-if="hasSyncFeedback" width="40%" />
-                        <div class="text--disabled body-1">{{ $t('Panels.MmuPanel.ClogDetection') }}</div>
+                        <div class="text--disabled body-1">{{ $t('Panels.MmuPanel.ClogTangleDetection') }}</div>
                     </div>
                 </v-col>
                 <v-col :cols="12 - col1Size">

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -86,6 +86,7 @@
                     <mmu-filament-status />
                     <div v-if="showClogDetection" class="text-center">
                         <mmu-clog-meter width="40%" />
+                        <mmu-flowguard-meter width="40%" />
                         <div class="text--disabled body-1">{{ $t('Panels.MmuPanel.ClogDetection') }}</div>
                     </div>
                 </v-col>

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -85,7 +85,7 @@
                     <div class="text-center body-1">{{ statusText }}</div>
                     <mmu-filament-status />
                     <div v-if="showClogDetection" class="text-center">
-                        <mmu-clog-meter width="40%" />
+                        <mmu-clog-meter v-if="hasMmuEncoder" width="40%" />
                         <mmu-flowguard-meter v-if="hasSyncFeedback" width="40%" />
                         <div class="text--disabled body-1">{{ $t('Panels.MmuPanel.ClogDetection') }}</div>
                     </div>

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -86,7 +86,7 @@
                     <mmu-filament-status />
                     <div v-if="showClogDetection" class="text-center">
                         <mmu-clog-meter width="40%" />
-                        <mmu-flowguard-meter width="40%" />
+                        <mmu-flowguard-meter v-if="hasSyncFeedback" width="40%" />
                         <div class="text--disabled body-1">{{ $t('Panels.MmuPanel.ClogDetection') }}</div>
                     </div>
                 </v-col>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -780,7 +780,7 @@
             }
         },
         "MmuPanel": {
-            "Active": "ACTIVE",
+            "Active": "Active",
             "ButtonCheckAllGates": "Check All Gates",
             "ButtonCheckGate": "Check Gate",
             "ButtonEject": "Eject",
@@ -796,8 +796,9 @@
             "ButtonUnlock": "Unlock",
             "Bypass": "Bypass",
             "Cancel": "Cancel",
-            "Clog": "CLOG",
+            "Clog": "Clog",
             "ClogDetection": "Clog Detection",
+            "ClogTangleDetection": "Clog/Tangle Detection",
             "Dialog": {
                 "AreYouSure": "Are you sure?"
             },
@@ -808,7 +809,7 @@
             "EditTtgMapTitle": "Map Tools / Filaments (Edit TTG Map)",
             "Encoder": "Encoder",
             "Extruder": "Extruder",
-            "Flow": "FLOW",
+            "Flow": "Flow",
             "Gate": "Gate",
             "GateMapDialog": {
                 "BadTemperature": "Temperature out of range",
@@ -831,7 +832,7 @@
                 "Temperature": "Temperature"
             },
             "Gear": "Gear",
-            "Guard": "GUARD",
+            "Guard": "Guard",
             "Headline": "Mmu",
             "LargeFilamentStatus": "Large Filament Status",
             "MmuMaintenance": "MMU Maintenance",
@@ -902,6 +903,7 @@
             "PreGate": "Pre-Gate",
             "RecoverState": "Fix MMU State",
             "ShowClogDetection": "Clog Detection",
+            "ShowClogTangleDetection": "Clog/Tangle Detection",
             "ShowDetails": "Filament Details",
             "ShowLogos": "Display Logo",
             "ShowName": "Display Unit Name",
@@ -911,7 +913,7 @@
                 "MultiColor": "This looks like a Multi Material Single Extruder print using {numTools} tools. You should probably review tool mapping",
                 "SingleColor": "This looks like a single color print but you don't have the bypass selected on your MMU. You may want to check the chosen tool"
             },
-            "Tangle": "TANGLE",
+            "Tangle": "Tangle",
             "Toolhead": "Toolhead",
             "ToolMapping": "Tool Mapping",
             "ToolTip": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -797,7 +797,6 @@
             "Bypass": "Bypass",
             "Cancel": "Cancel",
             "Clog": "Clog",
-            "ClogDetection": "Clog Detection",
             "ClogTangleDetection": "Clog/Tangle Detection",
             "Dialog": {
                 "AreYouSure": "Are you sure?"
@@ -903,7 +902,6 @@
             "Ok": "Ok",
             "PreGate": "Pre-Gate",
             "RecoverState": "Fix MMU State",
-            "ShowClogDetection": "Clog Detection",
             "ShowClogTangleDetection": "Clog/Tangle Detection",
             "ShowDetails": "Filament Details",
             "ShowLogos": "Display Logo",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -780,6 +780,7 @@
             }
         },
         "MmuPanel": {
+            "Active": "ACTIVE",
             "ButtonCheckAllGates": "Check All Gates",
             "ButtonCheckGate": "Check Gate",
             "ButtonEject": "Eject",
@@ -794,6 +795,7 @@
             "ButtonUnlock": "Unlock",
             "Bypass": "Bypass",
             "Cancel": "Cancel",
+            "Clog": "CLOG",
             "ClogDetection": "Clog Detection",
             "Dialog": {
                 "AreYouSure": "Are you sure?"
@@ -805,6 +807,7 @@
             "EditTtgMapTitle": "Map Tools / Filaments (Edit TTG Map)",
             "Encoder": "Encoder",
             "Extruder": "Extruder",
+            "Flow": "FLOW",
             "GateMapDialog": {
                 "BadTemperature": "Temperature out of range",
                 "ChooseSpool": "Choose Spool",
@@ -826,6 +829,7 @@
                 "Temperature": "Temperature"
             },
             "Gear": "Gear",
+            "Guard": "GUARD",
             "Headline": "Mmu",
             "LargeFilamentStatus": "Large Filament Status",
             "MmuMaintenance": "MMU Maintenance",
@@ -905,6 +909,7 @@
                 "MultiColor": "This looks like a Multi Material Single Extruder print using {numTools} tools. You should probably review tool mapping",
                 "SingleColor": "This looks like a single color print but you don't have the bypass selected on your MMU. You may want to check the chosen tool"
             },
+            "Tangle": "TANGLE",
             "Toolhead": "Toolhead",
             "ToolMapping": "Tool Mapping",
             "ToolTip": {


### PR DESCRIPTION
## Description
This adds an additional / replacement clog/tangle detection meter.   Whist clogging and general flowrate can be monitored with the current Clog meter when encoder is fitted.  This adds similar functionality for when a sync-feedback buffer is fitted but is enhanced because it can reliably differentiate between an extrude clog (or a slowed extrusion rate) and a tangle (where spool is preventing free filament movement).

In the case both encoder and sync-feedback buffer are fitted both meters will be displayed in same area.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
<img width="340" height="240" alt="Screenshot 2025-12-05 at 10 45 01 AM" src="https://github.com/user-attachments/assets/9636c51f-b404-4657-a225-22665cb32c1a" />


## [optional] Are there any post-deployment tasks we need to perform?
No action necessary. This meter will be an option if a sync-feedback buffer is installed (and user preference to show is enabled)

Signed off by: Paul Morgan <moggieuk@hotmail.com>
