### PR TITLE
fix(HappyHare): Allow unit gate wrapping

### DIFF
--- a/src/components/panels/Mmu/MmuUnit.vue
+++ b/src/components/panels/Mmu/MmuUnit.vue
@@ -7,7 +7,6 @@
                 :gate-index="gateIndex - 1 + firstGateNumber"
                 :mmu-machine-unit="mmuMachineUnit"
                 :show-details="showDetails"
-                :show-context-menu="showContextMenu"
                 :unhighlight-spools="unhighlightSpools"
                 :selected-gate="selectedGate"
                 :gate-pos="gatePos(idx)"
@@ -16,15 +15,11 @@
                 v-if="hasBypass"
                 :gate-index="TOOL_GATE_BYPASS"
                 :mmu-machine-unit="mmuMachineUnit"
-                :show-context-menu="false"
                 :selected-gate="selectedGate"
                 gate-pos="R"
                 @select-gate="selectGate" />
         </div>
-        <mmu-unit-footer
-            class="pt-0 position-relative"
-            :mmu-machine-unit="mmuMachineUnit"
-            :unit-index="unitIndex" />
+        <mmu-unit-footer class="pt-0 position-relative" :mmu-machine-unit="mmuMachineUnit" :unit-index="unitIndex" />
     </div>
 </template>
 <script lang="ts">
@@ -39,7 +34,6 @@ export default class MmuUnit extends Mixins(BaseMixin, MmuMixin) {
     @Prop({ required: true }) readonly selectedGate!: number
     @Prop({ required: true }) readonly unitIndex!: number
     @Prop({ default: false }) readonly showDetails!: boolean
-    @Prop({ default: false }) readonly showContextMenu!: boolean
     @Prop({ default: false }) readonly hideBypass!: boolean
     @Prop({ default: false }) readonly unhighlightSpools!: boolean
 
@@ -62,11 +56,7 @@ export default class MmuUnit extends Mixins(BaseMixin, MmuMixin) {
     }
 
     gatePos(idx: number) {
-        return idx === 0
-          ? 'L'
-          : idx  === (this.numGates - 1) && !this.hasBypass
-          ? "R"
-          : ''
+        return idx === 0 ? 'L' : idx === this.numGates - 1 && !this.hasBypass ? 'R' : ''
     }
 
     selectGate(gateIndex: number) {

--- a/src/components/panels/Mmu/MmuUnit.vue
+++ b/src/components/panels/Mmu/MmuUnit.vue
@@ -2,7 +2,7 @@
     <div class="mmu-unit d-inline-flex flex-column mx-1 rounded-lg mb-3">
         <div class="d-flex flex-wrap pt-3 px-4 position-relative">
             <mmu-unit-gate
-                v-for="(gateIndex, idx) in numGates"
+                v-for="gateIndex in numGates"
                 :key="gateIndex"
                 :gate-index="gateIndex - 1 + firstGateNumber"
                 :mmu-machine-unit="mmuMachineUnit"
@@ -10,7 +10,7 @@
                 :show-context-menu="showContextMenu"
                 :unhighlight-spools="unhighlightSpools"
                 :selected-gate="selectedGate"
-                :gate-pos="gatePos(idx)"
+                :has-bypass="hasBypass"
                 @select-gate="selectGate" />
             <mmu-unit-gate
                 v-if="hasBypass"
@@ -56,10 +56,6 @@ export default class MmuUnit extends Mixins(BaseMixin, MmuMixin) {
         if (this.hideBypass) return false
 
         return this.mmuMachineUnit?.has_bypass ?? true
-    }
-
-    gatePos(idx: number) {
-        return idx === 0 ? 'L' : idx === this.numGates - 1 && !this.hasBypass ? 'R' : ''
     }
 
     selectGate(gateIndex: number) {

--- a/src/components/panels/Mmu/MmuUnit.vue
+++ b/src/components/panels/Mmu/MmuUnit.vue
@@ -1,24 +1,28 @@
 <template>
     <div class="mmu-unit d-inline-flex flex-column mx-1 rounded-lg mb-3">
-        <div class="d-flex pt-3 px-4 mb-n7 position-relative">
+        <div class="d-flex flex-wrap pt-3 px-4 position-relative">
             <mmu-unit-gate
-                v-for="gateIndex in numGates"
+                v-for="(gateIndex, idx) in numGates"
                 :key="gateIndex"
                 :gate-index="gateIndex - 1 + firstGateNumber"
                 :mmu-machine-unit="mmuMachineUnit"
                 :show-details="showDetails"
+                :show-context-menu="showContextMenu"
                 :unhighlight-spools="unhighlightSpools"
                 :selected-gate="selectedGate"
+                :gate-pos="gatePos(idx)"
                 @select-gate="selectGate" />
             <mmu-unit-gate
                 v-if="hasBypass"
                 :gate-index="TOOL_GATE_BYPASS"
                 :mmu-machine-unit="mmuMachineUnit"
+                :show-context-menu="false"
                 :selected-gate="selectedGate"
+                gate-pos="R"
                 @select-gate="selectGate" />
         </div>
         <mmu-unit-footer
-            class="pt-8 position-relative zindex-3"
+            class="pt-0 position-relative"
             :mmu-machine-unit="mmuMachineUnit"
             :unit-index="unitIndex" />
     </div>
@@ -35,6 +39,7 @@ export default class MmuUnit extends Mixins(BaseMixin, MmuMixin) {
     @Prop({ required: true }) readonly selectedGate!: number
     @Prop({ required: true }) readonly unitIndex!: number
     @Prop({ default: false }) readonly showDetails!: boolean
+    @Prop({ default: false }) readonly showContextMenu!: boolean
     @Prop({ default: false }) readonly hideBypass!: boolean
     @Prop({ default: false }) readonly unhighlightSpools!: boolean
 
@@ -56,6 +61,14 @@ export default class MmuUnit extends Mixins(BaseMixin, MmuMixin) {
         return this.mmuMachineUnit?.has_bypass ?? true
     }
 
+    gatePos(idx: number) {
+        return idx === 0
+          ? 'L'
+          : idx  === (this.numGates - 1) && !this.hasBypass
+          ? "R"
+          : ''
+    }
+
     selectGate(gateIndex: number) {
         this.$emit('select-gate', gateIndex)
     }
@@ -70,9 +83,5 @@ export default class MmuUnit extends Mixins(BaseMixin, MmuMixin) {
 
 html.theme--light .mmu-unit {
     background: #f0f0f0;
-}
-
-.zindex-3 {
-    z-index: 3;
 }
 </style>

--- a/src/components/panels/Mmu/MmuUnit.vue
+++ b/src/components/panels/Mmu/MmuUnit.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="mmu-unit d-inline-flex flex-column mx-1 rounded-lg mb-3">
-        <div class="d-flex pt-3 px-4 mb-n7 position-relative">
+        <div class="d-flex flex-wrap pt-3 px-4 position-relative">
             <mmu-unit-gate
-                v-for="gateIndex in numGates"
+                v-for="(gateIndex, idx) in numGates"
                 :key="gateIndex"
                 :gate-index="gateIndex - 1 + firstGateNumber"
                 :mmu-machine-unit="mmuMachineUnit"
@@ -10,6 +10,7 @@
                 :show-context-menu="showContextMenu"
                 :unhighlight-spools="unhighlightSpools"
                 :selected-gate="selectedGate"
+                :gate-pos="gatePos(idx)"
                 @select-gate="selectGate" />
             <mmu-unit-gate
                 v-if="hasBypass"
@@ -17,12 +18,10 @@
                 :mmu-machine-unit="mmuMachineUnit"
                 :show-context-menu="false"
                 :selected-gate="selectedGate"
+                gate-pos="R"
                 @select-gate="selectGate" />
         </div>
-        <mmu-unit-footer
-            class="pt-8 position-relative zindex-3"
-            :mmu-machine-unit="mmuMachineUnit"
-            :unit-index="unitIndex" />
+        <mmu-unit-footer class="pt-0 position-relative" :mmu-machine-unit="mmuMachineUnit" :unit-index="unitIndex" />
     </div>
 </template>
 <script lang="ts">
@@ -59,6 +58,10 @@ export default class MmuUnit extends Mixins(BaseMixin, MmuMixin) {
         return this.mmuMachineUnit?.has_bypass ?? true
     }
 
+    gatePos(idx: number) {
+        return idx === 0 ? 'L' : idx === this.numGates - 1 && !this.hasBypass ? 'R' : ''
+    }
+
     selectGate(gateIndex: number) {
         this.$emit('select-gate', gateIndex)
     }
@@ -73,9 +76,5 @@ export default class MmuUnit extends Mixins(BaseMixin, MmuMixin) {
 
 html.theme--light .mmu-unit {
     background: #f0f0f0;
-}
-
-.zindex-3 {
-    z-index: 3;
 }
 </style>

--- a/src/components/panels/Mmu/MmuUnit.vue
+++ b/src/components/panels/Mmu/MmuUnit.vue
@@ -18,7 +18,6 @@
                 :mmu-machine-unit="mmuMachineUnit"
                 :show-context-menu="false"
                 :selected-gate="selectedGate"
-                gate-pos="R"
                 @select-gate="selectGate" />
         </div>
         <mmu-unit-footer class="pt-0 position-relative" :mmu-machine-unit="mmuMachineUnit" :unit-index="unitIndex" />

--- a/src/components/panels/Mmu/MmuUnitFooter.vue
+++ b/src/components/panels/Mmu/MmuUnitFooter.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="mmu-unit-footer d-flex flex-row align-center px-4 pb-1">
+    <div class="mmu-unit-footer zindex-4 d-flex flex-row align-center px-4 pb-1">
         <v-icon
             v-if="showLogos"
             class="mr-4 flex-grow-0 flex-shrink-0 opacity-70"
@@ -153,18 +153,19 @@ export default class MmuUnitFooter extends Mixins(BaseMixin, MmuMixin) {
 
 <style scoped>
 .mmu-unit-footer {
-    box-shadow: inset 0 4px 4px -4px #ffffff80;
-    background-image: linear-gradient(to bottom, #3c3c3c 0%, #2c2c2c 100%);
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
+    background: #2c2c2c;
+    border-radius: 0px 0px 8px 8px;
 }
 
 html.theme--light .mmu-unit-footer {
-    box-shadow: inset 0 4px 4px -4px #ffffff80;
-    background-image: linear-gradient(to bottom, #d0d0d0 0%, #f0f0f0ff 100%);
+    background: #f0f0f0;
 }
 
 .opacity-70 {
     opacity: 0.7;
+}
+
+.zindex-4 {
+    z-index: 4;
 }
 </style>

--- a/src/components/panels/Mmu/MmuUnitFooter.vue
+++ b/src/components/panels/Mmu/MmuUnitFooter.vue
@@ -154,7 +154,7 @@ export default class MmuUnitFooter extends Mixins(BaseMixin, MmuMixin) {
 <style scoped>
 .mmu-unit-footer {
     background: #2c2c2c;
-    border-radius: 0px 0px 8px 8px;
+    border-radius: 0 0 8px 8px;
 }
 
 html.theme--light .mmu-unit-footer {

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -12,7 +12,7 @@
                 :unhighlight-spools="unhighlightSpools"
                 @select-gate="selectGate" />
         </div>
-        <div class="mmu-unit-box d-flex zindex-3 pb-1 pt-2" :class="gateClass">
+        <div class="mmu-unit-box d-flex zindex-3 pb-1 pt-2 position-relative" :class="gateClass">
             <div class="d-flex w-100 gate-contents">
                 <span class="gate-number rounded cursor-pointer" :class="gateNumberClass" @click="selectGate">
                     {{ gateName }}
@@ -234,7 +234,6 @@ html.theme--light .mmu-unit-box {
 
 .left-gate {
     border-radius: 8px 0 0 0;
-    position: relative;
     margin-left: -16px;
     width: calc(100% + 16px);
 }
@@ -245,7 +244,6 @@ html.theme--light .mmu-unit-box {
 
 .right-gate {
     border-radius: 0 8px 0 0;
-    position: relative;
     margin-right: -16px;
     width: calc(100% + 16px);
 }

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="d-flex flex-column align-center">
-        <div v-longpress:500="openContextMenu" class="d-flex flex-wrap mb-n2 pt-1 position-relative" @contextmenu.prevent="openContextMenu($event)">
+        <div
+            v-longpress:500="openContextMenu"
+            class="d-flex flex-wrap mb-n2 pt-1 position-relative"
+            @contextmenu.prevent="openContextMenu($event)">
             <mmu-unit-gate-spool
                 class="position-relative zindex-1"
                 :gate-index="gateIndex"

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -1,34 +1,128 @@
 <template>
     <div class="d-flex flex-column align-center">
-        <mmu-unit-gate-spool
-            class="position-relative zindex-1"
-            :gate-index="gateIndex"
-            :show-details="showDetails"
-            :is-selected="isSelected"
-            :unhighlight-spools="unhighlightSpools"
-            @select-gate="selectGate" />
+        <!-- Important context menu -->
+        <v-menu
+            v-model="contextMenu"
+            transition="slide-y-transition"
+            :position-x="menuX"
+            :position-y="menuY"
+            :close-on-content-click="false"
+            :open-on-click="false"
+            absolute
+            offset-y>
+            <template #activator="{ attrs }">
+                <div
+                    class="d-flex flex-wrap mb-n2 pt-1 position-relative"
+                    v-bind="attrs"
+                    @contextmenu.prevent.stop="openContextMenu"
+                    @pointerdown="onPointerDown"
+                    @pointerup="onPointerUp"
+                    @pointercancel="onPointerUp"
+                    @pointerleave="onPointerUp">
+                    <mmu-unit-gate-spool
+                        class="position-relative zindex-1"
+                        :gate-index="gateIndex"
+                        :show-details="showDetails"
+                        :is-selected="isSelected"
+                        :unhighlight-spools="unhighlightSpools"
+                        @select-gate="selectGate" />
+                </div>
+            </template>
+            <v-list dense @mouseleave="closeContextMenu">
+                <v-subheader class="compact-subheader">Gate {{ gateIndex }}</v-subheader>
+                <v-divider />
+                <v-list-item>
+                    <v-btn
+                        small
+                        style="width: 100%"
+                        :disabled="!canSend"
+                        :loading="loadings.includes('mmu_select')"
+                        @click="gateCommand('MMU_SELECT')">
+                        <v-icon left>
+                            {{ mdiSwapHorizontal }}
+                        </v-icon>
+                        {{ $t('Panels.MmuPanel.ButtonSelect') }}
+                    </v-btn>
+                </v-list-item>
+                <v-list-item>
+                    <v-btn
+                        small
+                        style="width: 100%"
+                        :disabled="!canSend"
+                        :loading="loadings.includes('mmu_preload')"
+                        @click="gateCommand('MMU_PRELOAD')">
+                        <v-icon left>
+                            {{ mdiDownloadOutline }}
+                        </v-icon>
+                        {{ $t('Panels.MmuPanel.ButtonPreload') }}
+                    </v-btn>
+                </v-list-item>
+                <v-list-item>
+                    <v-btn
+                        small
+                        style="width: 100%"
+                        :disabled="!canSend"
+                        :loading="loadings.includes('mmu_eject')"
+                        @click="gateCommand('MMU_EJECT')">
+                        <v-icon left>
+                            {{ mdiEject }}
+                        </v-icon>
+                        {{ $t('Panels.MmuPanel.ButtonEject') }}
+                    </v-btn>
+                </v-list-item>
+            </v-list>
+        </v-menu>
 
-        <span class="gate-number rounded cursor-pointer" :class="gateNumberClass" @click="selectGate">
+        <div class="mmu-unit-box d-flex zindex-3 pb-1 pt-3"
+             :class="gateClass(gatePos)">
+        <div class="d-flex" style="width: 100%;"
+             :class="gateClassContents(gatePos)">
+        <span
+            class="gate-number rounded cursor-pointer"
+            :class="gateNumberClass"
+            @click="selectGate"
+        >
             {{ gateName }}
         </span>
+        </div>
+        </div>
     </div>
 </template>
+
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import MmuMixin, { MmuMachineUnit, TOOL_GATE_BYPASS } from '@/components/mixins/mmu'
+import { mdiSwapHorizontal, mdiDownloadOutline, mdiEject } from '@mdi/js'
 
 @Component
 export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
+    mdiSwapHorizontal = mdiSwapHorizontal
+    mdiDownloadOutline = mdiDownloadOutline
+    mdiEject = mdiEject
+
     @Prop({ required: true }) readonly gateIndex!: number
     @Prop({ required: true }) readonly mmuMachineUnit!: MmuMachineUnit
     @Prop({ default: false }) readonly showDetails!: boolean
+    @Prop({ default: false }) readonly showContextMenu!: boolean
     @Prop({ required: true }) readonly selectedGate!: number
     @Prop({ default: false }) readonly unhighlightSpools!: boolean
+    @Prop({ default: "" }) readonly gatePos!: string
+
+    closeTimeout: number | null = null
+    contextMenu = false
+    menuX = 0
+    menuY = 0
+
+    // Long-press state
+    longPressTimeout: number | null = null
+    longPressDuration = 500
+    isPressing = false
+    pressStartX = 0
+    pressStartY = 0
 
     get gateName() {
         if (this.gateIndex === TOOL_GATE_BYPASS) return 'Bypass'
-
         return this.gateIndex
     }
 
@@ -52,6 +146,102 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     selectGate() {
         this.$emit('select-gate', this.gateIndex)
     }
+
+    openContextMenu(e: MouseEvent) {
+        e.preventDefault()
+        this.openContextMenuAt(e.clientX, e.clientY)
+    }
+
+    openContextMenuAt(clientX: number, clientY: number) {
+        if (this.gateIndex < 0 || this.gateIndex === this.selectedGate || !this.showContextMenu) return
+
+        this.menuX = clientX - 20
+        this.menuY = clientY - 20
+
+        this.closeContextMenu()
+
+        this.contextMenu = true
+        this.closeTimeout = setTimeout(() => {
+            this.closeContextMenu()
+        }, 6000)
+    }
+
+    closeContextMenu() {
+        if (this.closeTimeout) {
+            clearTimeout(this.closeTimeout)
+        }
+        this.closeTimeout = null
+        this.contextMenu = false
+    }
+
+    onPointerDown(e: PointerEvent) {
+        if (this.gateIndex < 0 || this.gateIndex === this.selectedGate || !this.showContextMenu) return
+
+        dispatchEvent(new CustomEvent('mmu-close-all-menus'))
+
+        this.isPressing = true
+        this.pressStartX = e.clientX
+        this.pressStartY = e.clientY
+
+        this.clearLongPressTimeout()
+        this.longPressTimeout = setTimeout(() => {
+            if (this.isPressing) {
+                this.openContextMenuAt(this.pressStartX, this.pressStartY)
+            }
+            this.clearPressState()
+        }, this.longPressDuration)
+    }
+
+    onPointerUp() {
+        this.clearPressState()
+    }
+
+    clearPressState() {
+        this.isPressing = false
+        this.clearLongPressTimeout()
+    }
+
+    clearLongPressTimeout() {
+        if (this.longPressTimeout) {
+            clearTimeout(this.longPressTimeout)
+        }
+        this.longPressTimeout = null
+    }
+
+    mounted() {
+        addEventListener('mmu-close-all-menus', this.onGlobalCloseMenus)
+    }
+
+    beforeDestroy() {
+        removeEventListener('mmu-close-all-menus', this.onGlobalCloseMenus)
+
+        this.closeContextMenu()
+        this.clearLongPressTimeout()
+        this.isPressing = false
+    }
+
+    onGlobalCloseMenus = () => {
+        this.closeContextMenu()
+    }
+
+    gateCommand(command: string) {
+        const fullGcode = `${command} GATE=${this.gateIndex}`
+        const loading = command.toLowerCase()
+        this.doSend(fullGcode, loading)
+    }
+
+    gateClass(pos: string) {
+        return pos === 'L'
+          ? "left-gate"
+          : pos  === 'R'
+          ? "right-gate"
+          : ''
+    }
+
+    gateClassContents(pos: string) {
+        const baseClass = this.gateClass(pos)
+        return baseClass ? `${baseClass}-contents` : ''
+    }
 }
 </script>
 
@@ -60,7 +250,12 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     z-index: 1;
 }
 
+.zindex-3 {
+    z-index: 3;
+}
+
 .gate-number {
+    margin-left: 2px;
     border: 2px solid #808080;
     width: 80%;
     position: relative;
@@ -94,5 +289,50 @@ html.theme--light .gate-number {
 
 .gate-number.border-unknown {
     border-color: orange;
+}
+
+.v-list--dense .compact-subheader {
+    height: auto;
+    padding-bottom: 6px;
+    display: block;
+    font-size: 14px;
+    text-align: center;
+}
+
+.mmu-unit-box {
+    box-shadow: inset 0 4px 4px -4px #ffffff80;
+    background-image: linear-gradient(to bottom, #3c3c3c 0%, #2c2c2c 100%);
+    border-radius: 0px 0px 8px 8px;
+    justify-content: center;
+    width: 100%;
+}
+
+html.theme--light .mmu-unit-box {
+    box-shadow: inset 0 4px 4px -4px #ffffff80;
+    background-image: linear-gradient(to bottom, #c0c0c0 0%, #f0f0f0 100%);
+}
+
+.left-gate {
+    border-radius: 8px 0 0px 0px;
+    position: relative;
+    margin-left: -16px;
+    width: calc(100% + 16px);
+}
+
+.left-gate-contents {
+    width: 100%;
+    margin-left: 16px;
+}
+
+.right-gate {
+    border-radius: 0 8px 0px 0px;
+    position: relative;
+    margin-right: -16px;
+    width: calc(100% + 16px);
+}
+
+.right-gate-contents {
+    width: 100%;
+    margin-right: 16px;
 }
 </style>

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -13,7 +13,7 @@
                 @select-gate="selectGate" />
         </div>
         <div class="mmu-unit-box d-flex zindex-3 pb-1 pt-2" :class="gateClass">
-            <div class="d-flex" style="width: 100%" :class="gateClassContents">
+            <div class="d-flex w-100 gate-contents">
                 <span class="gate-number rounded cursor-pointer" :class="gateNumberClass" @click="selectGate">
                     {{ gateName }}
                 </span>
@@ -66,7 +66,7 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     @Prop({ default: false }) readonly showContextMenu!: boolean
     @Prop({ required: true }) readonly selectedGate!: number
     @Prop({ default: false }) readonly unhighlightSpools!: boolean
-    @Prop({ default: '' }) readonly gatePos!: string
+    @Prop({ default: false }) readonly hasBypass!: boolean
 
     closeTimeout: number | null = null
     contextMenu = false
@@ -103,20 +103,27 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
         ]
     }
 
-    get gateClass() {
-        if (this.gatePos === 'L') {
-            return 'left-gate'
-        }
+    get gatePosition() {
+        const firstGateNumber = this.mmuMachineUnit?.first_gate ?? 0
 
-        if (this.gatePos === 'R') {
-            return 'right-gate'
-        }
-
-        return ''
+        return this.gateIndex + 1 - firstGateNumber
     }
 
-    get gateClassContents() {
-        return this.gateClass ? `${this.gateClass}-contents` : ''
+    get firstGate() {
+        return this.gatePosition === 1
+    }
+
+    get lastGate() {
+        if (this.gateIndex === TOOL_GATE_BYPASS) return true
+
+        return this.gatePosition === this.mmuMachineUnit?.num_gates && !this.hasBypass
+    }
+
+    get gateClass() {
+        return {
+            'left-gate': this.firstGate,
+            'right-gate': this.lastGate,
+        }
     }
 
     selectGate() {
@@ -232,8 +239,7 @@ html.theme--light .mmu-unit-box {
     width: calc(100% + 16px);
 }
 
-.left-gate-contents {
-    width: 100%;
+.left-gate .gate-contents {
     margin-left: 16px;
 }
 
@@ -244,8 +250,13 @@ html.theme--light .mmu-unit-box {
     width: calc(100% + 16px);
 }
 
-.right-gate-contents {
-    width: 100%;
+.right-gate .gate-contents {
     margin-right: 16px;
+}
+
+.left-gate.right-gate {
+    border-radius: 8px 8px 0 0;
+    width: calc(100% + 32px);
+    margin-right: -16px;
 }
 </style>

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -24,14 +24,9 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import MmuMixin, { MmuMachineUnit, TOOL_GATE_BYPASS } from '@/components/mixins/mmu'
-import { mdiSwapHorizontal, mdiDownloadOutline, mdiEject } from '@mdi/js'
 
 @Component
 export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
-    mdiSwapHorizontal = mdiSwapHorizontal
-    mdiDownloadOutline = mdiDownloadOutline
-    mdiEject = mdiEject
-
     @Prop({ required: true }) readonly gateIndex!: number
     @Prop({ required: true }) readonly mmuMachineUnit!: MmuMachineUnit
     @Prop({ default: false }) readonly showDetails!: boolean

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -12,8 +12,8 @@
                 :unhighlight-spools="unhighlightSpools"
                 @select-gate="selectGate" />
         </div>
-        <div class="mmu-unit-box d-flex zindex-3 pb-1 pt-2" :class="gateClass(gatePos)">
-            <div class="d-flex" style="width: 100%" :class="gateClassContents(gatePos)">
+        <div class="mmu-unit-box d-flex zindex-3 pb-1 pt-2" :class="gateClass">
+            <div class="d-flex" style="width: 100%" :class="gateClassContents">
                 <span class="gate-number rounded cursor-pointer" :class="gateNumberClass" @click="selectGate">
                     {{ gateName }}
                 </span>
@@ -98,6 +98,22 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
         ]
     }
 
+    get gateClass() {
+        if (this.gatePos === 'L') {
+            return 'left-gate'
+        }
+
+        if (this.gatePos === 'R') {
+            return 'right-gate'
+        }
+
+        return ''
+    }
+
+    get gateClassContents() {
+        return this.gateClass ? `${this.gateClass}-contents` : ''
+    }
+
     selectGate() {
         this.$emit('select-gate', this.gateIndex)
     }
@@ -141,15 +157,6 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
 
     gateCommand(command: string) {
         this.doSend(`${command} GATE=${this.gateIndex}`)
-    }
-
-    gateClass(pos: string) {
-        return pos === 'L' ? 'left-gate' : pos === 'R' ? 'right-gate' : ''
-    }
-
-    gateClassContents(pos: string) {
-        const baseClass = this.gateClass(pos)
-        return baseClass ? `${baseClass}-contents` : ''
     }
 }
 </script>

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="d-flex flex-column align-center">
-        <div v-longpress:500="openContextMenu" class="d-flex" @contextmenu.prevent="openContextMenu($event)">
+        <div v-longpress:500="openContextMenu" class="d-flex flex-wrap mb-n2 pt-1 position-relative" @contextmenu.prevent="openContextMenu($event)">
             <mmu-unit-gate-spool
                 class="position-relative zindex-1"
                 :gate-index="gateIndex"
@@ -9,9 +9,13 @@
                 :unhighlight-spools="unhighlightSpools"
                 @select-gate="selectGate" />
         </div>
-        <span class="gate-number rounded cursor-pointer" :class="gateNumberClass" @click="selectGate">
-            {{ gateName }}
-        </span>
+        <div class="mmu-unit-box d-flex zindex-3 pb-1 pt-2" :class="gateClass(gatePos)">
+            <div class="d-flex" style="width: 100%" :class="gateClassContents(gatePos)">
+                <span class="gate-number rounded cursor-pointer" :class="gateNumberClass" @click="selectGate">
+                    {{ gateName }}
+                </span>
+            </div>
+        </div>
         <v-menu
             v-model="contextMenu"
             transition="slide-y-transition"
@@ -54,6 +58,7 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     @Prop({ default: false }) readonly showContextMenu!: boolean
     @Prop({ required: true }) readonly selectedGate!: number
     @Prop({ default: false }) readonly unhighlightSpools!: boolean
+    @Prop({ default: '' }) readonly gatePos!: string
 
     closeTimeout: number | null = null
     contextMenu = false
@@ -134,6 +139,15 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     gateCommand(command: string) {
         this.doSend(`${command} GATE=${this.gateIndex}`)
     }
+
+    gateClass(pos: string) {
+        return pos === 'L' ? 'left-gate' : pos === 'R' ? 'right-gate' : ''
+    }
+
+    gateClassContents(pos: string) {
+        const baseClass = this.gateClass(pos)
+        return baseClass ? `${baseClass}-contents` : ''
+    }
 }
 </script>
 
@@ -142,7 +156,12 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     z-index: 1;
 }
 
+.zindex-3 {
+    z-index: 3;
+}
+
 .gate-number {
+    margin-left: 2px;
     border: 2px solid #808080;
     width: 80%;
     position: relative;
@@ -176,5 +195,42 @@ html.theme--light .gate-number {
 
 .gate-number.border-unknown {
     border-color: orange;
+}
+
+.mmu-unit-box {
+    box-shadow: inset 0 4px 4px -4px #ffffff80;
+    background-image: linear-gradient(to bottom, #3c3c3c 0%, #2c2c2c 100%);
+    border-radius: 0px 0px 8px 8px;
+    justify-content: center;
+    width: 100%;
+}
+
+html.theme--light .mmu-unit-box {
+    box-shadow: inset 0 4px 4px -4px #ffffff80;
+    background-image: linear-gradient(to bottom, #c0c0c0 0%, #f0f0f0 100%);
+}
+
+.left-gate {
+    border-radius: 8px 0 0px 0px;
+    position: relative;
+    margin-left: -16px;
+    width: calc(100% + 16px);
+}
+
+.left-gate-contents {
+    width: 100%;
+    margin-left: 16px;
+}
+
+.right-gate {
+    border-radius: 0 8px 0px 0px;
+    position: relative;
+    margin-right: -16px;
+    width: calc(100% + 16px);
+}
+
+.right-gate-contents {
+    width: 100%;
+    margin-right: 16px;
 }
 </style>

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -1,90 +1,21 @@
 <template>
     <div class="d-flex flex-column align-center">
-        <!-- Important context menu -->
-        <v-menu
-            v-model="contextMenu"
-            transition="slide-y-transition"
-            :position-x="menuX"
-            :position-y="menuY"
-            :close-on-content-click="false"
-            :open-on-click="false"
-            absolute
-            offset-y>
-            <template #activator="{ attrs }">
-                <div
-                    class="d-flex flex-wrap mb-n2 pt-1 position-relative"
-                    v-bind="attrs"
-                    @contextmenu.prevent.stop="openContextMenu"
-                    @pointerdown="onPointerDown"
-                    @pointerup="onPointerUp"
-                    @pointercancel="onPointerUp"
-                    @pointerleave="onPointerUp">
-                    <mmu-unit-gate-spool
-                        class="position-relative zindex-1"
-                        :gate-index="gateIndex"
-                        :show-details="showDetails"
-                        :is-selected="isSelected"
-                        :unhighlight-spools="unhighlightSpools"
-                        @select-gate="selectGate" />
-                </div>
-            </template>
-            <v-list dense @mouseleave="closeContextMenu">
-                <v-subheader class="compact-subheader">Gate {{ gateIndex }}</v-subheader>
-                <v-divider />
-                <v-list-item>
-                    <v-btn
-                        small
-                        style="width: 100%"
-                        :disabled="!canSend"
-                        :loading="loadings.includes('mmu_select')"
-                        @click="gateCommand('MMU_SELECT')">
-                        <v-icon left>
-                            {{ mdiSwapHorizontal }}
-                        </v-icon>
-                        {{ $t('Panels.MmuPanel.ButtonSelect') }}
-                    </v-btn>
-                </v-list-item>
-                <v-list-item>
-                    <v-btn
-                        small
-                        style="width: 100%"
-                        :disabled="!canSend"
-                        :loading="loadings.includes('mmu_preload')"
-                        @click="gateCommand('MMU_PRELOAD')">
-                        <v-icon left>
-                            {{ mdiDownloadOutline }}
-                        </v-icon>
-                        {{ $t('Panels.MmuPanel.ButtonPreload') }}
-                    </v-btn>
-                </v-list-item>
-                <v-list-item>
-                    <v-btn
-                        small
-                        style="width: 100%"
-                        :disabled="!canSend"
-                        :loading="loadings.includes('mmu_eject')"
-                        @click="gateCommand('MMU_EJECT')">
-                        <v-icon left>
-                            {{ mdiEject }}
-                        </v-icon>
-                        {{ $t('Panels.MmuPanel.ButtonEject') }}
-                    </v-btn>
-                </v-list-item>
-            </v-list>
-        </v-menu>
-
-        <div class="mmu-unit-box d-flex zindex-3 pb-1 pt-3"
-             :class="gateClass(gatePos)">
-        <div class="d-flex" style="width: 100%;"
-             :class="gateClassContents(gatePos)">
-        <span
-            class="gate-number rounded cursor-pointer"
-            :class="gateNumberClass"
-            @click="selectGate"
-        >
-            {{ gateName }}
-        </span>
+        <div class="d-flex flex-wrap mb-n2 pt-1 position-relative">
+            <mmu-unit-gate-spool
+                class="position-relative zindex-1"
+                :gate-index="gateIndex"
+                :show-details="showDetails"
+                :is-selected="isSelected"
+                :unhighlight-spools="unhighlightSpools"
+                @select-gate="selectGate" />
         </div>
+
+        <div class="mmu-unit-box d-flex zindex-3 pb-1 pt-3" :class="gateClass(gatePos)">
+            <div class="d-flex" style="width: 100%" :class="gateClassContents(gatePos)">
+                <span class="gate-number rounded cursor-pointer" :class="gateNumberClass" @click="selectGate">
+                    {{ gateName }}
+                </span>
+            </div>
         </div>
     </div>
 </template>
@@ -104,22 +35,9 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     @Prop({ required: true }) readonly gateIndex!: number
     @Prop({ required: true }) readonly mmuMachineUnit!: MmuMachineUnit
     @Prop({ default: false }) readonly showDetails!: boolean
-    @Prop({ default: false }) readonly showContextMenu!: boolean
     @Prop({ required: true }) readonly selectedGate!: number
     @Prop({ default: false }) readonly unhighlightSpools!: boolean
-    @Prop({ default: "" }) readonly gatePos!: string
-
-    closeTimeout: number | null = null
-    contextMenu = false
-    menuX = 0
-    menuY = 0
-
-    // Long-press state
-    longPressTimeout: number | null = null
-    longPressDuration = 500
-    isPressing = false
-    pressStartX = 0
-    pressStartY = 0
+    @Prop({ default: '' }) readonly gatePos!: string
 
     get gateName() {
         if (this.gateIndex === TOOL_GATE_BYPASS) return 'Bypass'
@@ -147,83 +65,6 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
         this.$emit('select-gate', this.gateIndex)
     }
 
-    openContextMenu(e: MouseEvent) {
-        e.preventDefault()
-        this.openContextMenuAt(e.clientX, e.clientY)
-    }
-
-    openContextMenuAt(clientX: number, clientY: number) {
-        if (this.gateIndex < 0 || this.gateIndex === this.selectedGate || !this.showContextMenu) return
-
-        this.menuX = clientX - 20
-        this.menuY = clientY - 20
-
-        this.closeContextMenu()
-
-        this.contextMenu = true
-        this.closeTimeout = setTimeout(() => {
-            this.closeContextMenu()
-        }, 6000)
-    }
-
-    closeContextMenu() {
-        if (this.closeTimeout) {
-            clearTimeout(this.closeTimeout)
-        }
-        this.closeTimeout = null
-        this.contextMenu = false
-    }
-
-    onPointerDown(e: PointerEvent) {
-        if (this.gateIndex < 0 || this.gateIndex === this.selectedGate || !this.showContextMenu) return
-
-        dispatchEvent(new CustomEvent('mmu-close-all-menus'))
-
-        this.isPressing = true
-        this.pressStartX = e.clientX
-        this.pressStartY = e.clientY
-
-        this.clearLongPressTimeout()
-        this.longPressTimeout = setTimeout(() => {
-            if (this.isPressing) {
-                this.openContextMenuAt(this.pressStartX, this.pressStartY)
-            }
-            this.clearPressState()
-        }, this.longPressDuration)
-    }
-
-    onPointerUp() {
-        this.clearPressState()
-    }
-
-    clearPressState() {
-        this.isPressing = false
-        this.clearLongPressTimeout()
-    }
-
-    clearLongPressTimeout() {
-        if (this.longPressTimeout) {
-            clearTimeout(this.longPressTimeout)
-        }
-        this.longPressTimeout = null
-    }
-
-    mounted() {
-        addEventListener('mmu-close-all-menus', this.onGlobalCloseMenus)
-    }
-
-    beforeDestroy() {
-        removeEventListener('mmu-close-all-menus', this.onGlobalCloseMenus)
-
-        this.closeContextMenu()
-        this.clearLongPressTimeout()
-        this.isPressing = false
-    }
-
-    onGlobalCloseMenus = () => {
-        this.closeContextMenu()
-    }
-
     gateCommand(command: string) {
         const fullGcode = `${command} GATE=${this.gateIndex}`
         const loading = command.toLowerCase()
@@ -231,11 +72,7 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     }
 
     gateClass(pos: string) {
-        return pos === 'L'
-          ? "left-gate"
-          : pos  === 'R'
-          ? "right-gate"
-          : ''
+        return pos === 'L' ? 'left-gate' : pos === 'R' ? 'right-gate' : ''
     }
 
     gateClassContents(pos: string) {

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -215,7 +215,7 @@ html.theme--light .gate-number {
 .mmu-unit-box {
     box-shadow: inset 0 4px 4px -4px #ffffff80;
     background-image: linear-gradient(to bottom, #3c3c3c 0%, #2c2c2c 100%);
-    border-radius: 0px 0px 8px 8px;
+    border-radius: 0 0 8px 8px;
     justify-content: center;
     width: 100%;
 }
@@ -226,7 +226,7 @@ html.theme--light .mmu-unit-box {
 }
 
 .left-gate {
-    border-radius: 8px 0 0px 0px;
+    border-radius: 8px 0 0 0;
     position: relative;
     margin-left: -16px;
     width: calc(100% + 16px);
@@ -238,7 +238,7 @@ html.theme--light .mmu-unit-box {
 }
 
 .right-gate {
-    border-radius: 0 8px 0px 0px;
+    border-radius: 0 8px 0 0;
     position: relative;
     margin-right: -16px;
     width: calc(100% + 16px);


### PR DESCRIPTION
## Description
This restructures the MmuUnit display to allow for wrapping when MMU has a large number of gates.  It breaks neatly retaining correctly formatted footer.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
<img width="380" height="333" alt="Screenshot 2025-12-05 at 1 10 20 PM" src="https://github.com/user-attachments/assets/9a04ae0a-0d8e-4091-a55a-5018626ad402" />



## [optional] Are there any post-deployment tasks we need to perform?
Reduce Mmu Panel width to force wrapping of gates.

Signed off by: Paul Morgan <moggieuk@hotmail.com>
