### PR TITLE
fix(Dashboard): remove MMU-Panel, when no mmu module exists in Klipper

### DIFF
--- a/src/store/gui/getters.ts
+++ b/src/store/gui/getters.ts
@@ -96,6 +96,11 @@ export const getters: GetterTree<GuiState, any> = {
             allPanels = allPanels.filter((name) => name !== 'afc')
         }
 
+        // remove mmu panel, if no Happy Hare exists in Klipper
+        if (!rootState.printer?.mmu) {
+            allPanels = allPanels.filter((name) => name !== 'mmu')
+        }
+
         return allPanels
     },
 


### PR DESCRIPTION
## Description

This PR fix an issue with the default Dashboard panels. It will remove the `mmu`-panel, when no mmu module exists in Klipper.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings
For these screenshots, I deactivated the MMU-Plugin and activated the AFC-Plugin. So it should only display the AFC panel, but it display both in the list.

before:
<img width="912" height="571" alt="grafik" src="https://github.com/user-attachments/assets/db05c280-b91d-4a8f-8bb5-c6dbc501e8c0" />

after:
<img width="914" height="566" alt="grafik" src="https://github.com/user-attachments/assets/608cc510-300f-4314-962c-0214df5f1238" />

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
