### PR TITLE
fix(Dashboard): use ArmoredTurtle logo for the AFC-Panel

### DIFF
--- a/src/components/mixins/dashboard.ts
+++ b/src/components/mixins/dashboard.ts
@@ -16,6 +16,7 @@ import {
     mdiAdjust,
     mdiMulticast,
 } from '@mdi/js'
+import { afcIconLogo } from '@/plugins/afcIcons'
 
 @Component
 export default class DashboardMixin extends BaseMixin {
@@ -73,6 +74,8 @@ export default class DashboardMixin extends BaseMixin {
                 return mdiAdjust
             case 'mmu':
                 return mdiMulticast
+            case 'afc':
+                return afcIconLogo
 
             default:
                 return mdiInformation


### PR DESCRIPTION
## Description

This PR fix the icon for the AFC-Panel in the dashboard settings.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
<img width="914" height="566" alt="grafik" src="https://github.com/user-attachments/assets/2d697ba2-7a46-46b8-8d94-55cb24298e65" />

after:
<img width="920" height="572" alt="grafik" src="https://github.com/user-attachments/assets/c9d339b6-0973-4fbf-95c6-f99c873bb655" />

## [optional] Are there any post-deployment tasks we need to perform?

none
