### PR TITLE
fix(HappyHare): Adds "loading" feedback to main action buttons to prevent accidental double invocation

### DIFF
--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -74,15 +74,6 @@ export interface Mmu {
     sync_feedback_bias_raw: number
     sync_feedback_enabled: boolean
     sync_feedback_state: string
-    flowguard?: {
-        trigger: string
-        reason: string
-        level: number
-        max_clog: number
-        max_tangle: number
-        active: boolean
-        enabled: boolean
-    }
     clog_detection: number
     clog_detection_enabled: number
     endless_spool: number

--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -70,8 +70,19 @@ export interface Mmu {
         | typeof ACTION_PURGING
     has_bypass: boolean
     sync_drive: boolean
+    sync_feedback_bias_modelled: number
+    sync_feedback_bias_raw: number
     sync_feedback_enabled: boolean
     sync_feedback_state: string
+    flowguard?: {
+        trigger: string
+        reason: string
+        level: number
+        max_clog: number
+        max_tangle: number
+        active: boolean
+        enabled: boolean
+    }
     clog_detection: number
     clog_detection_enabled: number
     endless_spool: number
@@ -314,9 +325,9 @@ export default class MmuMixin extends Mixins(BaseMixin) {
         return this.mmuSensors ? this.mmuSensors[sensorName] : undefined
     }
 
-    doSend(gcode: string) {
+    doSend(gcode: string, loading: string = 'mmu') {
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
-        this.$socket.emit('printer.gcode.script', { script: gcode })
+        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading })
     }
 
     formColorString(color: string | null) {

--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -314,7 +314,7 @@ export default class MmuMixin extends Mixins(BaseMixin) {
         return this.mmuSensors ? this.mmuSensors[sensorName] : undefined
     }
 
-    doSend(gcode: string, loading: string = 'mmu') {
+    doSend(gcode: string, loading: string | null = null) {
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
         this.$socket.emit('printer.gcode.script', { script: gcode }, { loading })
     }

--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -70,8 +70,6 @@ export interface Mmu {
         | typeof ACTION_PURGING
     has_bypass: boolean
     sync_drive: boolean
-    sync_feedback_bias_modelled: number
-    sync_feedback_bias_raw: number
     sync_feedback_enabled: boolean
     sync_feedback_state: string
     clog_detection: number

--- a/src/components/panels/Mmu/MmuControlsButton.vue
+++ b/src/components/panels/Mmu/MmuControlsButton.vue
@@ -8,7 +8,6 @@
                 :large="btnSizeLarge"
                 color="secondary"
                 :disabled="disabled"
-                :loading="loadings.includes(command.toLowerCase())"
                 v-bind="attrs"
                 v-on="on"
                 @click="doSend(command)">

--- a/src/components/panels/Mmu/MmuControlsButton.vue
+++ b/src/components/panels/Mmu/MmuControlsButton.vue
@@ -8,9 +8,10 @@
                 :large="btnSizeLarge"
                 color="secondary"
                 :disabled="disabled"
+                :loading="loadings.includes(command.toLowerCase())"
                 v-bind="attrs"
                 v-on="on"
-                @click="doSend(command)">
+                @click="doSend(command, command.toLowerCase())">
                 <v-icon :left="!showTooltip">{{ icon }}</v-icon>
                 <template v-if="!showTooltip">{{ text }}</template>
             </v-btn>

--- a/src/components/panels/Mmu/MmuControlsButton.vue
+++ b/src/components/panels/Mmu/MmuControlsButton.vue
@@ -8,7 +8,7 @@
                 :large="btnSizeLarge"
                 color="secondary"
                 :disabled="disabled"
-                :loading="loadings.includes(command.toLowerCase())"
+                :loading="btnLoading"
                 v-bind="attrs"
                 v-on="on"
                 @click="doSend(command, command.toLowerCase())">
@@ -47,6 +47,10 @@ export default class MmuControlsButton extends Mixins(BaseMixin, MmuMixin) {
 
     get btnSizeLarge() {
         return this.size === 'large'
+    }
+
+    get btnLoading() {
+        return this.loadings.includes(this.command.toLowerCase())
     }
 
     calcBtnSize() {

--- a/src/components/panels/Mmu/MmuControlsButton.vue
+++ b/src/components/panels/Mmu/MmuControlsButton.vue
@@ -11,7 +11,7 @@
                 :loading="btnLoading"
                 v-bind="attrs"
                 v-on="on"
-                @click="doSend(command, command.toLowerCase())">
+                @click="sendCommand">
                 <v-icon :left="!showTooltip">{{ icon }}</v-icon>
                 <template v-if="!showTooltip">{{ text }}</template>
             </v-btn>
@@ -71,6 +71,10 @@ export default class MmuControlsButton extends Mixins(BaseMixin, MmuMixin) {
 
     beforeDestroy() {
         window.removeEventListener('resize', this.calcBtnSize)
+    }
+
+    sendCommand() {
+        this.doSend(this.command, this.command.toLowerCase())
     }
 
     @Watch('largeFilamentStatus')

--- a/src/components/panels/Mmu/MmuControlsButton.vue
+++ b/src/components/panels/Mmu/MmuControlsButton.vue
@@ -8,6 +8,7 @@
                 :large="btnSizeLarge"
                 color="secondary"
                 :disabled="disabled"
+                :loading="loadings.includes(command.toLowerCase())"
                 v-bind="attrs"
                 v-on="on"
                 @click="doSend(command)">

--- a/src/components/panels/Mmu/MmuPanelSettings.vue
+++ b/src/components/panels/Mmu/MmuPanelSettings.vue
@@ -6,7 +6,7 @@
             </v-btn>
         </template>
         <v-list>
-            <v-list-item v-if="hasMmuEncoder" class="minHeight36">
+            <v-list-item v-if="hasMmuEncoder || hasSyncFeedback" class="minHeight36">
                 <v-checkbox
                     v-model="showClogDetection"
                     class="mt-0"

--- a/src/components/panels/Mmu/MmuPanelSettings.vue
+++ b/src/components/panels/Mmu/MmuPanelSettings.vue
@@ -6,7 +6,7 @@
             </v-btn>
         </template>
         <v-list>
-            <v-list-item v-if="hasMmuEncoder || hasSyncFeedback" class="minHeight36">
+            <v-list-item v-if="hasMmuEncoder" class="minHeight36">
                 <v-checkbox
                     v-model="showClogDetection"
                     class="mt-0"

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -85,7 +85,7 @@
                     <div class="text-center body-1">{{ statusText }}</div>
                     <mmu-filament-status />
                     <div v-if="showClogDetection" class="text-center">
-                        <mmu-clog-meter v-if="hasMmuEncoder" width="40%" />
+                        <mmu-clog-meter width="40%" />
                         <div class="text--disabled body-1">{{ $t('Panels.MmuPanel.ClogDetection') }}</div>
                     </div>
                 </v-col>

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -34,7 +34,7 @@
                             small
                             class="w-100"
                             :loading="loadings.includes('mmu_stats')"
-                            @click="doSend('MMU_STATS SHOWCOUNTS=1')">
+                            @click="doSend('MMU_STATS SHOWCOUNTS=1', 'mmu_stats')">
                             <v-icon left>{{ mdiNoteText }}</v-icon>
                             {{ $t('Panels.MmuPanel.ButtonPrintStats') }}
                         </v-btn>
@@ -57,7 +57,7 @@
                             class="w-100"
                             :disabled="!canSend"
                             :loading="loadings.includes('mmu_check_gates')"
-                            @click="doSend('MMU_CHECK_GATES')">
+                            @click="doSend('MMU_CHECK_GATES', 'mmu_check_gates')">
                             <v-icon left>{{ mdiCheckAll }}</v-icon>
                             {{ $t('Panels.MmuPanel.ButtonCheckAllGates') }}
                         </v-btn>
@@ -70,7 +70,7 @@
         <v-card-text :class="{ 'mmu-disabled': !enabled }">
             <v-row>
                 <v-col class="pb-0">
-                    <MmuUnit
+                    <mmu-unit
                         v-for="i in mmuNumUnits"
                         :key="i"
                         :selected-gate="mmuGate"
@@ -85,7 +85,7 @@
                     <div class="text-center body-1">{{ statusText }}</div>
                     <mmu-filament-status />
                     <div v-if="showClogDetection" class="text-center">
-                        <mmu-clog-meter width="40%" />
+                        <mmu-clog-meter v-if="hasMmuEncoder" width="40%" />
                         <div class="text--disabled body-1">{{ $t('Panels.MmuPanel.ClogDetection') }}</div>
                     </div>
                 </v-col>
@@ -205,11 +205,11 @@ export default class MmuPanel extends Mixins(BaseMixin, MmuMixin) {
 
     selectGate(gateIndex: number) {
         if (gateIndex === TOOL_GATE_BYPASS) {
-            this.doSend('MMU_SELECT BYPASS=1')
+            this.doSend('MMU_SELECT BYPASS=1', 'mmu_select')
             return
         }
 
-        this.doSend(`MMU_SELECT GATE=${gateIndex}`)
+        this.doSend(`MMU_SELECT GATE=${gateIndex}`, 'mmu_select')
     }
 
     get showClogDetection() {
@@ -294,7 +294,7 @@ export default class MmuPanel extends Mixins(BaseMixin, MmuMixin) {
     }
 
     handleSyncSpoolman() {
-        this.doSend('MMU_SPOOLMAN REFRESH=1 QUIET=1')
+        this.doSend('MMU_SPOOLMAN REFRESH=1 QUIET=1', 'mmu_spoolman')
     }
 }
 </script>


### PR DESCRIPTION
## Description
This PR completes the missing elements in the mmu interface, and adds ability to activate "loadings" when action buttons are pressed.  The primary use case to provide some user feedback and to help prevent double invocation of potentially long running operations.  (PR#2324 does the same for context menu actions)

## Related Tickets & Documents
https://github.com/mainsail-crew/mainsail/pull/2324

## Mobile & Desktop Screenshots/Recordings
E.g. Loading on eject action:
<img width="437" height="374" alt="Screenshot 2025-12-06 at 12 06 47 PM" src="https://github.com/user-attachments/assets/5b8d0a27-b359-4cf3-9a14-b4d7668164b9" />


## [optional] Are there any post-deployment tasks we need to perform?
n/a

Signed off by: Paul Morgan [moggieuk@hotmail.com](mailto:moggieuk@hotmail.com)