### PR TITLE
fix(HappyHare): Removed spin button from spool_id

### DIFF
--- a/src/components/dialogs/MmuEditGateMapDialogGateDetails.vue
+++ b/src/components/dialogs/MmuEditGateMapDialogGateDetails.vue
@@ -25,7 +25,7 @@
                             :label="$t('Panels.MmuPanel.GateMapDialog.SpoolmanId')"
                             :rules="spoolIdRules"
                             :disabled="disableSpoolId"
-                            :hide-spin-buttons="disableSpoolId"
+                            hide-spin-buttons
                             outlined
                             dense
                             hide-details />


### PR DESCRIPTION
## Description:
This PR removes the spin button from the spool_id chooser.  Using it to scroll through filaments will reset any other gate using that id on the way.  Best option is to simply remove it and require the use of the chooser or manual id entry.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings


## [optional] Are there any post-deployment tasks we need to perform?
Edit spool with assigned spool_id .. the spinner should not appear
