### PR TITLE
fix(HappyHare): Ensure spoolman spool info is available.

### DIFF
--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -296,6 +296,17 @@ export default class MmuPanel extends Mixins(BaseMixin, MmuMixin) {
     handleSyncSpoolman() {
         this.doSend('MMU_SPOOLMAN REFRESH=1 QUIET=1')
     }
+
+    mounted() {
+        this.refreshSpoolman() // Need spool info for spool rack display
+    }
+
+    refreshSpoolman() {
+        const actionName = 'server/spoolman/refreshSpools'
+        if (this.$store && this.$store._actions && this.$store._actions[actionName]) {
+            this.$store.dispatch(actionName)
+        }
+    }
 }
 </script>
 


### PR DESCRIPTION
## Description:
A change to spoolman dialog in the v2.15.0 development branch meant that spool info is not longer refreshed on start.  This fix ensures that the necessary information is available to display the main MMU panel (including spool %) and ready for filament editing in the gate map editor dialog.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
n/a

## [optional] Are there any post-deployment tasks we need to perform?

