### PR TITLE
refactor(HappyHare): Moved now common functions to mixin base class

### DIFF
--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -201,6 +201,22 @@ export default class MmuMixin extends Mixins(BaseMixin) {
         return 'encoder' in (this.mmu ?? {})
     }
 
+    get hasFilamentProportionalSensor() {
+        return this.hasMmuSensor('filament_proportional')
+    }
+
+    get hasFilamentCompressionSensor() {
+        return this.hasMmuSensor('filament_compression')
+    }
+
+    get hasFilamentTensionSensor() {
+        return this.hasMmuSensor('filament_tension')
+    }
+
+    get hasSyncFeedback(): boolean {
+        return this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
+    }
+
     get mmuMachine(): MmuMachine | undefined {
         return this.$store.state.printer.mmu_machine ?? undefined
     }

--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -35,10 +35,6 @@ import MmuMixin, { FILAMENT_POS_END_BOWDEN } from '@/components/mixins/mmu'
 
 @Component
 export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, MmuMixin) {
-    get hasSyncFeedback(): boolean {
-        return this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
-    }
-
     get syncFeedbackActive(): boolean {
         return this.hasSyncFeedback && this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
     }
@@ -51,18 +47,6 @@ export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, Mmu
         const bias = this.mmu?.sync_feedback_bias_modelled ?? 0.0
         const yPos = bias * 12 + 234
         return yPos
-    }
-
-    get hasFilamentProportionalSensor() {
-        return this.hasMmuSensor('filament_proportional')
-    }
-
-    get hasFilamentCompressionSensor() {
-        return this.hasMmuSensor('filament_compression')
-    }
-
-    get hasFilamentTensionSensor() {
-        return this.hasMmuSensor('filament_tension')
     }
 
     get filamentCompressionSensor() {


### PR DESCRIPTION
## Description
The PR moves now common getters to the base mixin.  These getters are related to the availability and capability of the sync-feedback buffer sensor.

## Related Tickets & Documents
(this is a dependency of other HappyHare PRs)

## Mobile & Desktop Screenshots/Recordings
n/a

## [optional] Are there any post-deployment tasks we need to perform?
n/a
