### PR TITLE
fix(HappHare): add missing sync-feedback bias

### DIFF
--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -203,22 +203,6 @@ export default class MmuMixin extends Mixins(BaseMixin) {
         return 'encoder' in (this.mmu ?? {})
     }
 
-    get hasFilamentProportionalSensor() {
-        return this.hasMmuSensor('filament_proportional')
-    }
-
-    get hasFilamentCompressionSensor() {
-        return this.hasMmuSensor('filament_compression')
-    }
-
-    get hasFilamentTensionSensor() {
-        return this.hasMmuSensor('filament_tension')
-    }
-
-    get hasSyncFeedback(): boolean {
-        return this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
-    }
-
     get mmuMachine(): MmuMachine | undefined {
         return this.$store.state.printer.mmu_machine ?? undefined
     }

--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -70,6 +70,8 @@ export interface Mmu {
         | typeof ACTION_PURGING
     has_bypass: boolean
     sync_drive: boolean
+    sync_feedback_bias_modelled: number
+    sync_feedback_bias_raw: number
     sync_feedback_enabled: boolean
     sync_feedback_state: string
     clog_detection: number

--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -201,6 +201,22 @@ export default class MmuMixin extends Mixins(BaseMixin) {
         return 'encoder' in (this.mmu ?? {})
     }
 
+    get hasFilamentProportionalSensor() {
+        return this.hasMmuSensor('filament_proportional')
+    }
+
+    get hasFilamentCompressionSensor() {
+        return this.hasMmuSensor('filament_compression')
+    }
+
+    get hasFilamentTensionSensor() {
+        return this.hasMmuSensor('filament_tension')
+    }
+
+    get hasSyncFeedback(): boolean {
+        return this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
+    }
+
     get mmuMachine(): MmuMachine | undefined {
         return this.$store.state.printer.mmu_machine ?? undefined
     }

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -357,7 +357,7 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
     }
 
     get toolClass() {
-        return this.mmuGate === TOOL_GATE_BYPASS ? 'tool-bypass' : 'tool-text'
+        return this.mmuTool === TOOL_GATE_BYPASS ? 'tool-bypass' : 'tool-text'
     }
 
     get toolText() {
@@ -452,8 +452,8 @@ html.theme--light .fil-background {
 }
 
 .tool-bypass {
-    font-size: 16px;
-    font-weight: normal;
+    font-size: 18px;
+    font-weight: bold;
 }
 
 @keyframes fadeInOut {

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -357,7 +357,7 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
     }
 
     get toolClass() {
-        return this.mmuTool === TOOL_GATE_BYPASS ? 'tool-bypass' : 'tool-text'
+        return this.mmuGate === TOOL_GATE_BYPASS ? 'tool-bypass' : 'tool-text'
     }
 
     get toolText() {
@@ -452,8 +452,8 @@ html.theme--light .fil-background {
 }
 
 .tool-bypass {
-    font-size: 18px;
-    font-weight: bold;
+    font-size: 16px;
+    font-weight: normal;
 }
 
 @keyframes fadeInOut {

--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -7,7 +7,7 @@
                 transition: 'transform 250ms ease',
             }" />
         <use xlink:href="#sync-feedback-buffer-box" transform="translate(232, 212)" />
-        <g v-if="syncFeedbackActive">
+        <g v-if="syncFeedbackEnabled && syncFeedbackActive">
             <transition name="fade">
                 <g v-if="filamentTensionSensor && filamentCompressionSensor" key="neutral">
                     <text x="298" y="240">Neutral</text>
@@ -36,11 +36,12 @@ import MmuMixin, { FILAMENT_POS_END_BOWDEN } from '@/components/mixins/mmu'
 @Component
 export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, MmuMixin) {
     get syncFeedbackActive(): boolean {
-        return this.hasSyncFeedback && this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
+        return this.hasSyncFeedbackEnabled && this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
     }
 
     get syncFeedbackEnabled() {
-        return this.mmu?.sync_feedback_enabled ?? false
+        const enabled = this.mmu?.sync_feedback_enabled ?? false
+        return this.hasSyncFeedback && enabled
     }
 
     get syncFeedbackBiasModelled() {

--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -7,7 +7,7 @@
                 transition: 'transform 250ms ease',
             }" />
         <use xlink:href="#sync-feedback-buffer-box" transform="translate(232, 212)" />
-        <g v-if="syncFeedbackEnabled && syncFeedbackActive">
+        <g v-if="syncFeedbackActive">
             <transition name="fade">
                 <g v-if="filamentTensionSensor && filamentCompressionSensor" key="neutral">
                     <text x="298" y="240">Neutral</text>
@@ -36,12 +36,9 @@ import MmuMixin, { FILAMENT_POS_END_BOWDEN } from '@/components/mixins/mmu'
 @Component
 export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, MmuMixin) {
     get syncFeedbackActive(): boolean {
-        return this.hasSyncFeedbackEnabled && this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
-    }
-
-    get syncFeedbackEnabled() {
         const enabled = this.mmu?.sync_feedback_enabled ?? false
-        return this.hasSyncFeedback && enabled
+        const loaded = this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
+        return this.hasSyncFeedback && enabled && loaded
     }
 
     get syncFeedbackBiasModelled() {

--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -35,6 +35,10 @@ import MmuMixin, { FILAMENT_POS_END_BOWDEN } from '@/components/mixins/mmu'
 
 @Component
 export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, MmuMixin) {
+    get hasSyncFeedback(): boolean {
+        return this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
+    }
+
     get syncFeedbackActive(): boolean {
         const enabled = this.mmu?.sync_feedback_enabled ?? false
         const loaded = this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
@@ -48,6 +52,18 @@ export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, Mmu
     get syncFeedbackPistonPos(): int {
         const yPos = this.syncFeedbackBiasModelled * 12 + 234
         return yPos
+    }
+
+    get hasFilamentProportionalSensor() {
+        return this.hasMmuSensor('filament_proportional')
+    }
+
+    get hasFilamentCompressionSensor() {
+        return this.hasMmuSensor('filament_compression')
+    }
+
+    get hasFilamentTensionSensor() {
+        return this.hasMmuSensor('filament_tension')
     }
 
     get filamentCompressionSensor() {

--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -35,10 +35,6 @@ import MmuMixin, { FILAMENT_POS_END_BOWDEN } from '@/components/mixins/mmu'
 
 @Component
 export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, MmuMixin) {
-    get hasSyncFeedback(): boolean {
-        return this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
-    }
-
     get syncFeedbackActive(): boolean {
         return this.hasSyncFeedback && this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
     }
@@ -47,22 +43,13 @@ export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, Mmu
         return this.mmu?.sync_feedback_enabled ?? false
     }
 
+    get syncFeedbackBiasModelled() {
+        return this.mmu?.sync_feedback_bias_modelled ?? 0.0
+    }
+
     get syncFeedbackPistonPos(): int {
-        const bias = this.mmu?.sync_feedback_bias_modelled ?? 0.0
-        const yPos = bias * 12 + 234
+        const yPos = this.syncFeedbackBiasModelled * 12 + 234
         return yPos
-    }
-
-    get hasFilamentProportionalSensor() {
-        return this.hasMmuSensor('filament_proportional')
-    }
-
-    get hasFilamentCompressionSensor() {
-        return this.hasMmuSensor('filament_compression')
-    }
-
-    get hasFilamentTensionSensor() {
-        return this.hasMmuSensor('filament_tension')
     }
 
     get filamentCompressionSensor() {

--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -49,9 +49,8 @@ export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, Mmu
         return this.mmu?.sync_feedback_bias_modelled ?? 0.0
     }
 
-    get syncFeedbackPistonPos(): int {
-        const yPos = this.syncFeedbackBiasModelled * 12 + 234
-        return yPos
+    get syncFeedbackPistonPos(): number {
+        return this.syncFeedbackBiasModelled * 12 + 234
     }
 
     get hasFilamentProportionalSensor() {


### PR DESCRIPTION
## Description
This PR adds the missing sync_feedback_bias_* fields to Mmu interface and makes clear the usage in the FilamentStatusSyncFeedback component.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
n/a

## [optional] Are there any post-deployment tasks we need to perform?
