### PR TITLE
fix(StatusPanel): fix context menu handling

### DIFF
--- a/src/components/panels/Status/GcodefilesEntry.vue
+++ b/src/components/panels/Status/GcodefilesEntry.vue
@@ -146,6 +146,7 @@ import { defaultBigThumbnailBackground } from '@/store/variables'
 import AddBatchToQueueDialog from '@/components/dialogs/AddBatchToQueueDialog.vue'
 import { convertPrintStatusIcon, convertPrintStatusIconColor, escapePath, formatPrintTime } from '@/plugins/helpers'
 import GcodefilesThumbnail from '@/components/panels/Gcodefiles/GcodefilesThumbnail.vue'
+import { CLOSE_CONTEXT_MENU, EventBus } from '@/plugins/eventBus'
 
 @Component({
     components: {
@@ -248,15 +249,17 @@ export default class StatusPanelGcodefilesEntry extends Mixins(BaseMixin, Contro
     }
 
     showContextMenu(e: any) {
-        if (this.contextMenuShow) return
-
         e?.preventDefault()
+        EventBus.$emit(CLOSE_CONTEXT_MENU)
+
         this.contextMenuX = e?.clientX || e?.pageX || window.screenX / 2
         this.contextMenuY = e?.clientY || e?.pageY || window.screenY / 2
 
-        this.$nextTick(() => {
-            this.contextMenuShow = true
-        })
+        this.contextMenuShow = true
+    }
+
+    closeContextMenu() {
+        this.contextMenuShow = false
     }
 
     addToQueue() {
@@ -312,6 +315,11 @@ export default class StatusPanelGcodefilesEntry extends Mixins(BaseMixin, Contro
 
     mounted() {
         this.renameFileNewName = this.filename
+        EventBus.$on(CLOSE_CONTEXT_MENU, this.closeContextMenu)
+    }
+
+    beforeDestroy() {
+        EventBus.$off(CLOSE_CONTEXT_MENU, this.closeContextMenu)
     }
 }
 </script>

--- a/src/components/panels/Status/HistoryEntry.vue
+++ b/src/components/panels/Status/HistoryEntry.vue
@@ -88,6 +88,8 @@ import { defaultBigThumbnailBackground, thumbnailBigMin, thumbnailSmallMax, thum
 import { ServerHistoryStateJobWithCount } from '@/store/server/history/types'
 import { FileStateFileThumbnail } from '@/store/files/types'
 import { convertPrintStatusIcon, escapePath, formatPrintTime } from '@/plugins/helpers'
+import { CLOSE_CONTEXT_MENU, EventBus } from '@/plugins/eventBus'
+
 @Component
 export default class StatusPanelHistoryEntry extends Mixins(BaseMixin) {
     mdiCloseThick = mdiCloseThick
@@ -214,15 +216,16 @@ export default class StatusPanelHistoryEntry extends Mixins(BaseMixin) {
 
     openContextMenu(e: any) {
         e?.preventDefault()
+        EventBus.$emit(CLOSE_CONTEXT_MENU)
 
-        if (this.showContextMenu) {
-            this.showContextMenu = false
-            return
-        }
-
-        this.showContextMenu = true
         this.contextMenuX = e?.clientX || e?.pageX || window.screenX / 2
         this.contextMenuY = e?.clientY || e?.pageY || window.screenY / 2
+
+        this.showContextMenu = true
+    }
+
+    closeContextMenu() {
+        this.showContextMenu = false
     }
 
     startPrint() {
@@ -253,6 +256,14 @@ export default class StatusPanelHistoryEntry extends Mixins(BaseMixin) {
         return `${this.apiUrl}/server/files/gcodes/${escapePath(relative_url + thumbnail.relative_path)}?timestamp=${
             this.job.metadata.modified
         }`
+    }
+
+    mounted() {
+        EventBus.$on(CLOSE_CONTEXT_MENU, this.closeContextMenu)
+    }
+
+    beforeDestroy() {
+        EventBus.$off(CLOSE_CONTEXT_MENU, this.closeContextMenu)
     }
 }
 </script>

--- a/src/components/panels/Status/JobqueueEntry.vue
+++ b/src/components/panels/Status/JobqueueEntry.vue
@@ -54,6 +54,7 @@ import { ServerJobQueueStateJob } from '@/store/server/jobQueue/types'
 import { mdiCloseThick, mdiCounter, mdiDragVertical, mdiFile, mdiPlay, mdiPlaylistRemove } from '@mdi/js'
 import { defaultBigThumbnailBackground } from '@/store/variables'
 import GcodefilesThumbnail from '@/components/panels/Gcodefiles/GcodefilesThumbnail.vue'
+import { CLOSE_CONTEXT_MENU, EventBus } from '@/plugins/eventBus'
 
 @Component({
     components: { GcodefilesThumbnail },
@@ -161,15 +162,16 @@ export default class StatusPanelJobqueueEntry extends Mixins(BaseMixin) {
 
     openContextMenu(e: any) {
         e?.preventDefault()
+        EventBus.$emit(CLOSE_CONTEXT_MENU)
 
-        if (this.showContextMenu) {
-            this.showContextMenu = false
-            return
-        }
-
-        this.showContextMenu = true
         this.contextMenuX = e?.clientX || e?.pageX || window.screenX / 2
         this.contextMenuY = e?.clientY || e?.pageY || window.screenY / 2
+
+        this.showContextMenu = true
+    }
+
+    closeContextMenu() {
+        this.showContextMenu = false
     }
 
     printJob() {
@@ -184,6 +186,14 @@ export default class StatusPanelJobqueueEntry extends Mixins(BaseMixin) {
         const ids = [...(this.job.combinedIds ?? []), this.job.job_id]
 
         this.$store.dispatch('server/jobQueue/deleteFromQueue', ids)
+    }
+
+    mounted() {
+        EventBus.$on(CLOSE_CONTEXT_MENU, this.closeContextMenu)
+    }
+
+    beforeDestroy() {
+        EventBus.$off(CLOSE_CONTEXT_MENU, this.closeContextMenu)
     }
 }
 </script>

--- a/src/components/panels/Temperature/TemperaturePanelListItem.vue
+++ b/src/components/panels/Temperature/TemperaturePanelListItem.vue
@@ -90,7 +90,7 @@ import {
     mdiThermometer,
 } from '@mdi/js'
 import { additionalSensors, opacityHeaterActive, opacityHeaterInactive } from '@/store/variables'
-import { CLOSE_TEMPERATURE_CONTEXT_MENU, EventBus } from '@/plugins/eventBus'
+import { CLOSE_CONTEXT_MENU, EventBus } from '@/plugins/eventBus'
 
 @Component
 export default class TemperaturePanelListItem extends Mixins(BaseMixin) {
@@ -305,15 +305,15 @@ export default class TemperaturePanelListItem extends Mixins(BaseMixin) {
     }
 
     mounted() {
-        EventBus.$on(CLOSE_TEMPERATURE_CONTEXT_MENU, this.closeContextMenu)
+        EventBus.$on(CLOSE_CONTEXT_MENU, this.closeContextMenu)
     }
 
     beforeDestroy() {
-        EventBus.$off(CLOSE_TEMPERATURE_CONTEXT_MENU, this.closeContextMenu)
+        EventBus.$off(CLOSE_CONTEXT_MENU, this.closeContextMenu)
     }
 
     openContextMenu(event: MouseEvent) {
-        EventBus.$emit(CLOSE_TEMPERATURE_CONTEXT_MENU)
+        EventBus.$emit(CLOSE_CONTEXT_MENU)
 
         this.showContextMenu = true
         this.contextMenuX = event?.clientX || event?.pageX || window.screenX / 2

--- a/src/plugins/eventBus.ts
+++ b/src/plugins/eventBus.ts
@@ -1,4 +1,4 @@
 import Vue from 'vue'
 export const EventBus = new Vue()
 
-export const CLOSE_TEMPERATURE_CONTEXT_MENU = 'close-temperature-context-menu'
+export const CLOSE_CONTEXT_MENU = 'close-context-menu'


### PR DESCRIPTION
## Description

This PR fix the handling with context menus in the StatusPanel. When you open another context menu, it will close the one before. It also rename the event from the TemperaturePanel, to close "all" context menu and you cannot see multiple ones at the same time.


## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

before:
<img width="1148" height="817" alt="grafik" src="https://github.com/user-attachments/assets/5046162d-55af-4cef-aefc-8d3e39cd9b9d" />

## [optional] Are there any post-deployment tasks we need to perform?

none
