### PR TITLE
refactor(StatusPanel): remove old/unused code in GcodefilesEntry

### DIFF
--- a/src/components/panels/Status/GcodefilesEntry.vue
+++ b/src/components/panels/Status/GcodefilesEntry.vue
@@ -130,7 +130,6 @@ import ControlMixin from '@/components/mixins/control'
 import { FileStateGcodefile } from '@/store/files/types'
 import StartPrintDialog from '@/components/dialogs/StartPrintDialog.vue'
 import {
-    mdiFile,
     mdiPlay,
     mdiPlaylistPlus,
     mdiFire,
@@ -142,7 +141,6 @@ import {
     mdiCloseThick,
 } from '@mdi/js'
 import Panel from '@/components/ui/Panel.vue'
-import { defaultBigThumbnailBackground } from '@/store/variables'
 import AddBatchToQueueDialog from '@/components/dialogs/AddBatchToQueueDialog.vue'
 import { convertPrintStatusIcon, convertPrintStatusIconColor, escapePath, formatPrintTime } from '@/plugins/helpers'
 import GcodefilesThumbnail from '@/components/panels/Gcodefiles/GcodefilesThumbnail.vue'
@@ -156,7 +154,6 @@ import GcodefilesThumbnail from '@/components/panels/Gcodefiles/GcodefilesThumbn
     },
 })
 export default class StatusPanelGcodefilesEntry extends Mixins(BaseMixin, ControlMixin) {
-    mdiFile = mdiFile
     mdiPlay = mdiPlay
     mdiPlaylistPlus = mdiPlaylistPlus
     mdiFire = mdiFire
@@ -189,18 +186,6 @@ export default class StatusPanelGcodefilesEntry extends Mixins(BaseMixin, Contro
 
     get styleContentTdWidth() {
         return `width: ${this.contentTdWidth}px;`
-    }
-
-    get bigThumbnailBackground() {
-        return this.$store.state.gui.uiSettings.bigThumbnailBackground ?? defaultBigThumbnailBackground
-    }
-
-    get bigThumbnailTooltipColor() {
-        if (defaultBigThumbnailBackground.toLowerCase() === this.bigThumbnailBackground.toLowerCase()) {
-            return undefined
-        }
-
-        return this.bigThumbnailBackground
     }
 
     get existsMetadata() {


### PR DESCRIPTION
## Description

This PR just remove old/unused code from the GcodefilesEntry in the StatusPanel. I think all these components are deprecated since the gcode-thumbnail component.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
