### PR TITLE
fix: Happy Hare eject button disabling logic

### DIFF
--- a/src/components/panels/Mmu/MmuControls.vue
+++ b/src/components/panels/Mmu/MmuControls.vue
@@ -71,6 +71,7 @@ import MmuMixin, {
     GATE_AVAILABLE_FROM_BUFFER,
     FILAMENT_POS_UNLOADED,
     GATE_UNKNOWN,
+    GATE_EMPTY,
 } from '@/components/mixins/mmu'
 import { mdiDownloadOutline, mdiEject, mdiCheck, mdiAutoFix, mdiThermometerPlus, mdiDownload, mdiUpload } from '@mdi/js'
 import MmuControlsButton from '@/components/panels/Mmu/MmuControlsButton.vue'
@@ -102,7 +103,7 @@ export default class MmuControls extends Mixins(BaseMixin, MmuMixin) {
     }
 
     get btnEjectDisabled(): boolean {
-        return !this.canSend || [GATE_AVAILABLE, GATE_AVAILABLE_FROM_BUFFER].includes(this.currentGateStatus)
+        return !this.canSend || this.currentGateStatus === GATE_EMPTY
     }
 
     get btnUnloadDisabled() {


### PR DESCRIPTION
### Description

The logic for disabling the filament eject button in Happy Hare UI was copied from the preload button. This does not make sense - preload is supposed to be ran when the gate is empty and new filament is loaded, while eject if the gate is loaded and we want to remove the filament from it.
This is reflected by Happy Hare internal implementation MMU_EJECT, which exits with a "Filament not loaded" message if it does not detect filament.

### Related Tickets & Documents

None.