### PR TITLE
fix(Spoolman): fix init load from spool db

### DIFF
--- a/src/store/server/spoolman/actions.ts
+++ b/src/store/server/spoolman/actions.ts
@@ -123,8 +123,6 @@ export const actions: ActionTree<ServerSpoolmanState, RootState> = {
     },
 
     refreshSpools({ dispatch }) {
-        window.console.log('Refreshing spools...')
-
         Vue.$socket.emit(
             'server.spoolman.proxy',
             {


### PR DESCRIPTION
## Description

This PR adds the init spool db refresh to the spoolman modul init action. This was not necessary without HappyHare or AFC, because it loads the current spool and the other spools are only needed when you open the "chose spool dialog".

## Related Tickets & Documents

- https://github.com/mainsail-crew/mainsail/pull/2319

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
