### PR TITLE
fix(HappyHare): Clog detection meter(s) dependent on encoder OR sync-feedback

### DIFF
--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -215,7 +215,7 @@ export default class MmuPanel extends Mixins(BaseMixin, MmuMixin) {
     }
 
     get showClogDetection() {
-        return this.hasMmuEncoder && this.$store.state.gui.view.mmu.showClogDetection
+        return (this.hasMmuEncoder || this.hasSyncFeedback) && this.$store.state.gui.view.mmu.showClogDetection
     }
 
     get showTtgMap() {


### PR DESCRIPTION
## Description
There are two clog/tangle detection meters - one based on MMU encoder the other dependent on sync-feedback buffer.   This change allows EITHER to display the components.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
n/a .. just a logic change on when the part of the panel is displayed

## [optional] Are there any post-deployment tasks we need to perform?
n/a
