### PR TITLE
feat(HappyHare): Adds tiny numeric indicator of sensor position for Proportional Feedback sync-feedback buffers

### DIFF
--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -19,6 +19,9 @@
                 <rect x="3" y="0" width="30" height="40" rx="3" ry="3" fill="none" stroke-width="1.5" />
                 <path d="M-15 -4 L-6 0 L-15 4 Z" stroke-width="1" fill-opacity="0.6" />
                 <path d="M8 40 L 28 40" stroke-width="4" />
+                <text x="-22" y="4" font-size="11px" text-anchor="end" style="fill: var(--color-outline)">
+                    {{ syncFeedbackPistonText }}
+                </text>
             </g>
             <g
                 id="sync-feedback-buffer-box"
@@ -412,6 +415,18 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
 
     get isGripped() {
         return this.mmuGrip === 'Gripped' || this.mmuServo === 'Down'
+    }
+
+    get syncFeedbackPistonText() {
+        if (this.hasFilamentProportionalSensor) {
+            const bias = this.syncFeedbackBiasModelled
+            return bias.toFixed(2)
+        }
+        return ''
+    }
+
+    get syncFeedbackBiasModelled() {
+        return this.mmu?.sync_feedback_bias_modelled ?? 0.0
     }
 }
 </script>

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -19,7 +19,7 @@
                 <rect x="3" y="0" width="30" height="40" rx="3" ry="3" fill="none" stroke-width="1.5" />
                 <path d="M-15 -4 L-6 0 L-15 4 Z" stroke-width="1" fill-opacity="0.6" />
                 <path d="M8 40 L 28 40" stroke-width="4" />
-                <text x="-22" y="4" font-size="11px" text-anchor="end" style="fill: var(--color-outline)">
+                <text v-if="hasFilamentProportionalSensor" x="-22" y="4" font-size="11px" text-anchor="end" style="fill: var(--color-outline)">
                     {{ syncFeedbackPistonText }}
                 </text>
             </g>

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -418,15 +418,7 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
     }
 
     get syncFeedbackPistonText() {
-        if (this.hasFilamentProportionalSensor) {
-            const bias = this.syncFeedbackBiasModelled
-            return bias.toFixed(2)
-        }
-        return ''
-    }
-
-    get syncFeedbackBiasModelled() {
-        return this.mmu?.sync_feedback_bias_modelled ?? 0.0
+        return (this.mmu?.sync_feedback_bias_modelled ?? 0.0).toFixed(2)
     }
 }
 </script>


### PR DESCRIPTION
Description
This PR adds a small numeric next to buffer position for new class of proportional (analog) sensors.  The reason is the EKF (Extended Kalman Filter) for sync-feedback in Happy Hare means the buffer will almost always be centered. This indicator helps to see the minor corrections that are taking place.

Related Tickets & Documents
n/a

Mobile & Desktop Screenshots/Recordings
<img width="231" height="299" alt="Screenshot 2025-12-16 at 12 50 30 AM" src="https://github.com/user-attachments/assets/95bbc597-acf2-4298-bf90-04b41aeb4708" />


[optional] Are there any post-deployment tasks we need to perform?
n/a
