### PR TITLE
feat(HappyHare): Added flowrate % to flowguard meter when using proportional sensor

### DIFF
--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -74,6 +74,7 @@ export interface Mmu {
     sync_feedback_bias_raw: number
     sync_feedback_enabled: boolean
     sync_feedback_state: string
+    sync_feedback_flow_rate: number
     flowguard?: {
         trigger: string
         reason: string

--- a/src/components/panels/Mmu/MmuFlowguardMeter.vue
+++ b/src/components/panels/Mmu/MmuFlowguardMeter.vue
@@ -95,10 +95,10 @@
             stroke-dashoffset="0"
             stroke-dasharray="18,63" />
 
-        <text x="70" y="58" text-anchor="middle" class="small-text-color" font-size="12px">
+        <text x="70" y="56" text-anchor="middle" class="small-text-color" font-size="12px">
             {{ $t('Panels.MmuPanel.Flow').toUpperCase() }}
         </text>
-        <text x="70" y="72" text-anchor="middle" class="small-text-color" font-size="12px">
+        <text x="70" y="69" text-anchor="middle" class="small-text-color" font-size="12px">
             {{ $t('Panels.MmuPanel.Guard').toUpperCase() }}
         </text>
         <text
@@ -107,9 +107,9 @@
             y="90"
             text-anchor="middle"
             class="small-text-color"
-            font-size="12px"
+            :font-size="flowrateTextSize"
             font-weight="bold">
-            {{ $t('Panels.MmuPanel.Active').toUpperCase() }}
+            {{ flowrateText }}
         </text>
         <text v-if="flowguardTrigger" x="70" y="90" text-anchor="middle" class="small-text-warning" font-size="16px">
             {{ flowguardTrigger }}
@@ -153,6 +153,21 @@ export default class MmuFlowguardMeter extends Mixins(BaseMixin, MmuMixin) {
 
     get flowguardTrigger() {
         return (this.mmu?.flowguard?.trigger ?? '').toUpperCase()
+    }
+
+    get flowrateText() {
+        if (this.hasFilamentProportionalSensor) {
+            const flow_rate = this.mmu?.sync_feedback_flow_rate ?? 100.0
+            return `${Math.round(flow_rate)}%`
+        }
+        return this.$t('Panels.MmuPanel.Active').toUpperCase()
+    }
+
+    get flowrateTextSize() {
+        if (this.hasFilamentProportionalSensor) {
+            return '18px'
+        }
+        return '14px'
     }
 
     get maxClog() {


### PR DESCRIPTION
Description
This PR adds an estimation of flowrate to the "flowguard" meter when an analog sync-feedback sensor is used.  This works by comparing the active bias in the sensor compared to last tuned value. This gives indication when under-extruding with % decreasing down from 100%.   For non-analog sensors with switches the simple "ACTIVE" text is displayed instead.

Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
Before (existing):
<img width="122" height="136" alt="Screenshot 2025-12-16 at 1 19 21 AM" src="https://github.com/user-attachments/assets/1f84cb94-f69c-445d-9d35-aa44cf05f55f" />

After (IF analog sensor fitted):
<img width="131" height="131" alt="Screenshot 2025-12-16 at 1 19 57 AM" src="https://github.com/user-attachments/assets/c7a87966-54be-415b-8806-281892291805" />

## [optional] Are there any post-deployment tasks we need to perform?
n/a .. works only with analog sync-feedback sensors.
