### PR TITLE
fix(StatusPanel): fix filename exists check in rename gcodefile dialog

### DIFF
--- a/src/components/dialogs/GcodefilesRenameFileDialog.vue
+++ b/src/components/dialogs/GcodefilesRenameFileDialog.vue
@@ -1,8 +1,8 @@
 <template>
-    <v-dialog :value="showDialog" width="400">
+    <v-dialog v-model="showDialog" width="400">
         <panel :title="$t('Files.RenameFile')" card-class="gcodefiles-rename-file-dialog" :margin-bottom="false">
             <template #buttons>
-                <v-btn icon tile @click="closePrompt">
+                <v-btn icon tile @click="showDialog = false">
                     <v-icon>{{ mdiCloseThick }}</v-icon>
                 </v-btn>
             </template>
@@ -18,7 +18,7 @@
             </v-card-text>
             <v-card-actions>
                 <v-spacer />
-                <v-btn text @click="closePrompt">{{ $t('Files.Cancel') }}</v-btn>
+                <v-btn text @click="showDialog = false">{{ $t('Files.Cancel') }}</v-btn>
                 <v-btn :disabled="isInvalidName || name.length === 0" color="primary" text @click="renameFileAction">
                     {{ $t('Files.Rename') }}
                 </v-btn>
@@ -28,7 +28,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop, Ref, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Ref, VModel, Watch } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import Panel from '@/components/ui/Panel.vue'
 import { mdiCloseThick } from '@mdi/js'
@@ -44,7 +44,7 @@ export default class GcodefilesRenameFileDialog extends Mixins(BaseMixin, Gcodef
     name = ''
     isInvalidName = true
 
-    @Prop({ type: Boolean, default: false }) showDialog!: boolean
+    @VModel({ type: Boolean }) showDialog!: boolean
     @Prop({ type: Object, required: true }) item!: FileStateGcodefile
     @Ref('inputFieldRenameFile') readonly inputFieldRenameFile!: HTMLInputElement
 
@@ -67,11 +67,7 @@ export default class GcodefilesRenameFileDialog extends Mixins(BaseMixin, Gcodef
             { action: 'files/getMove' }
         )
 
-        this.closePrompt()
-    }
-
-    closePrompt() {
-        this.$emit('close')
+        this.showDialog = false
     }
 
     @Watch('showDialog')

--- a/src/components/panels/Gcodefiles/GcodefilesPanelTableRowFile.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelTableRowFile.vue
@@ -117,10 +117,7 @@
             :is-visible="showAddBatchToQueueDialog"
             :filename="item.full_filename"
             @close="showAddBatchToQueueDialog = false" />
-        <gcodefiles-rename-file-dialog
-            :item="item"
-            :show-dialog="showRenameFileDialog"
-            @close="showRenameFileDialog = false" />
+        <gcodefiles-rename-file-dialog v-model="showRenameFileDialog" :item="item" />
         <gcodefiles-duplicate-file-dialog
             :item="item"
             :show-dialog="showDuplicateFileDialog"

--- a/src/components/panels/Status/GcodefilesEntry.vue
+++ b/src/components/panels/Status/GcodefilesEntry.vue
@@ -73,31 +73,7 @@
             :is-visible="showAddBatchToQueueDialog"
             :filename="filename"
             @close="showAddBatchToQueueDialog = false" />
-        <v-dialog v-model="showRenameFileDialog" :max-width="400">
-            <panel
-                :title="$t('Files.RenameFile')"
-                card-class="dashboard-files-rename-file-dialog"
-                :margin-bottom="false">
-                <template #buttons>
-                    <v-btn icon tile @click="showRenameFileDialog = false">
-                        <v-icon>{{ mdiCloseThick }}</v-icon>
-                    </v-btn>
-                </template>
-                <v-card-text>
-                    <v-text-field
-                        v-model="renameFileNewName"
-                        :label="$t('Files.Name')"
-                        required
-                        autofocus
-                        @keyup.enter="renameFile" />
-                </v-card-text>
-                <v-card-actions>
-                    <v-spacer></v-spacer>
-                    <v-btn color="" text @click="showRenameFileDialog = false">{{ $t('Files.Cancel') }}</v-btn>
-                    <v-btn color="primary" text @click="renameFile">{{ $t('Files.Rename') }}</v-btn>
-                </v-card-actions>
-            </panel>
-        </v-dialog>
+        <gcodefiles-rename-file-dialog v-model="showRenameFileDialog" :item="item" />
         <v-dialog v-model="showDeleteDialog" max-width="400">
             <panel :title="$t('Files.Delete')" card-class="gcode-files-delete-dialog" :margin-bottom="false">
                 <template #buttons>


### PR DESCRIPTION
## Description

This PR fix the rename function in the dashboard StatusPanel. There was the "file exists" rule missing. I switched to the SFC dialog from the Gcodefiles page, so it need less components/code to add this function here.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
