### PR TITLE
fix(HappyHare): Fixes animated filament position so filament doesn't go backwards

### DIFF
--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -320,10 +320,6 @@ export default class MmuMixin extends Mixins(BaseMixin) {
         return this.mmuSettings?.gate_homing_endstop
     }
 
-    get configExtruderHomingEndstop(): string {
-        return this.mmuSettings?.extruder_homing_endstop
-    }
-
     get canSend(): boolean {
         const idleTimeout = this.$store.state.printer.idle_timeout?.state ?? ''
 

--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -320,6 +320,10 @@ export default class MmuMixin extends Mixins(BaseMixin) {
         return this.mmuSettings?.gate_homing_endstop
     }
 
+    get configExtruderHomingEndstop(): string {
+        return this.mmuSettings?.extruder_homing_endstop
+    }
+
     get canSend(): boolean {
         const idleTimeout = this.$store.state.printer.idle_timeout?.state ?? ''
 

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -317,13 +317,8 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
     get endOfBowdenPos() {
         if (typeof this.toolheadSensor === 'boolean' && !this.configExtruderForceHoming) return POSITIONS.END_BOWDEN
 
-        if (
-            this.configExtruderHomingEndstop === 'none' ||
-            this.configExtruderHomingEndstop === 'collision' ||
-            this.configExtruderHomingEndstop === 'mmu_gear_touch' ||
-            this.configExtruderHomingEndstop === 'filament_compression'
-        )
-            return POSITIONS.EXTRUDER_ENTRANCE
+        const homingEndstops = ['none', 'collision', 'mmu_gear_touch', 'filament_compression']
+        if (homingEndstops.includes(this.configExtruderHomingEndstop)) return POSITIONS.EXTRUDER_ENTRANCE
 
         if (this.configExtruderHomingEndstop === 'extruder') return POSITIONS.EXTRUDER
 

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -354,6 +354,10 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
         return (this.$store.state.printer.configfile.config.mmu?.extruder_force_homing ?? 0) === 1
     }
 
+    get configExtruderHomingEndstop() {
+        return this.mmuSettings?.extruder_homing_endstop
+    }
+
     get gateSensorName() {
         const unit = this.getMmuMachineUnit(this.mmuUnit)
         const multiGate = unit?.multi_gear ?? false

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -317,8 +317,8 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
     get endOfBowdenPos() {
         if (typeof this.toolheadSensor === 'boolean' && !this.configExtruderForceHoming) return POSITIONS.END_BOWDEN
 
-        const homingEndstops = ['none', 'collision', 'mmu_gear_touch', 'filament_compression']
-        if (homingEndstops.includes(this.configExtruderHomingEndstop)) return POSITIONS.EXTRUDER_ENTRANCE
+        const extruderHomingEndstops = ['none', 'collision', 'mmu_gear_touch', 'filament_compression']
+        if (extruderHomingEndstops.includes(this.configExtruderHomingEndstop)) return POSITIONS.EXTRUDER_ENTRANCE
 
         if (this.configExtruderHomingEndstop === 'extruder') return POSITIONS.EXTRUDER
 
@@ -350,7 +350,7 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
     }
 
     get configExtruderHomingEndstop() {
-        return this.mmuSettings?.extruder_homing_endstop
+        return this.mmuSettings?.extruder_homing_endstop ?? 'none'
     }
 
     get gateSensorName() {

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -315,17 +315,15 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
     }
 
     get endOfBowdenPos() {
-        if (
-            typeof this.toolheadSensor === 'boolean' &&
-            !this.configExtruderForceHoming
-        ) return POSITIONS.END_BOWDEN
+        if (typeof this.toolheadSensor === 'boolean' && !this.configExtruderForceHoming) return POSITIONS.END_BOWDEN
 
         if (
             this.configExtruderHomingEndstop === 'none' ||
             this.configExtruderHomingEndstop === 'collision' ||
             this.configExtruderHomingEndstop === 'mmu_gear_touch' ||
             this.configExtruderHomingEndstop === 'filament_compression'
-        ) return POSITIONS.EXTRUDER_ENTRANCE
+        )
+            return POSITIONS.EXTRUDER_ENTRANCE
 
         if (this.configExtruderHomingEndstop === 'extruder') return POSITIONS.EXTRUDER
 


### PR DESCRIPTION
## Description
This PR fixes two bugs in the animated rendering of the filament in the bowden:
1) If was possible for the filament to appear to go backwards slightly because the gate_homing_endstop was used where the extruder_homing_endstop should have been used.
2) It correctly sets the end of bowden position for ALL the "endstop" and sensor types including fixing the logic for the existence of valid toolhead sensor.  Previously this condition required sensor to be triggered which wasn't correct.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
Component modified: (no visual change other than corrected position in two cases):
<img width="303" height="442" alt="Screenshot 2025-12-16 at 11 00 23 PM" src="https://github.com/user-attachments/assets/66aa2078-b665-497f-9383-08f75464b491" />


## [optional] Are there any post-deployment tasks we need to perform?
n/a