### PR TITLE
refactor: replace vue-resize with ResizeObserver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
                 "vue-meta": "^2.4.0",
                 "vue-observe-visibility": "^1.0.0",
                 "vue-property-decorator": "^9.1.2",
-                "vue-resize": "^1.0.1",
                 "vue-toast-notification": "^1.0.1",
                 "vuedraggable": "^2.24.3",
                 "vuetify": "^2.7.2",
@@ -1776,6 +1775,7 @@
             "version": "7.27.0",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
             "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+            "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -10081,17 +10081,6 @@
             "peerDependencies": {
                 "vue": "*",
                 "vue-class-component": "*"
-            }
-        },
-        "node_modules/vue-resize": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-1.0.1.tgz",
-            "integrity": "sha512-z5M7lJs0QluJnaoMFTIeGx6dIkYxOwHThlZDeQnWZBizKblb99GSejPnK37ZbNE/rVwDcYcHY+Io+AxdpY952w==",
-            "dependencies": {
-                "@babel/runtime": "^7.13.10"
-            },
-            "peerDependencies": {
-                "vue": "^2.6.0"
             }
         },
         "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
         "vue-meta": "^2.4.0",
         "vue-observe-visibility": "^1.0.0",
         "vue-property-decorator": "^9.1.2",
-        "vue-resize": "^1.0.1",
         "vue-toast-notification": "^1.0.1",
         "vuedraggable": "^2.24.3",
         "vuetify": "^2.7.2",

--- a/src/components/gcodeviewer/Viewer.vue
+++ b/src/components/gcodeviewer/Viewer.vue
@@ -207,7 +207,6 @@
                     type="file"
                     @change="fileSelected" />
             </v-card-text>
-            <resize-observer @notify="handleResize" />
         </panel>
         <v-snackbar v-model="loading" :timeout="-1" fixed right bottom>
             <div>
@@ -362,6 +361,8 @@ export default class Viewer extends Mixins(BaseMixin) {
 
     fileData: string = ''
 
+    resizeObserver: ResizeObserver | null = null
+
     @Prop({ type: String, default: '', required: false }) declare filename: string
     @Ref('fileInput') declare fileInput: HTMLInputElement
     @Ref('viewerCanvasContainer') declare viewerCanvasContainer: HTMLElement
@@ -382,9 +383,10 @@ export default class Viewer extends Mixins(BaseMixin) {
         await this.init()
 
         if (this.loadedFile !== null) this.scrubFileSize = viewer.fileSize
-        if (viewer) {
-            this.fileData = viewer.fileData
-        }
+        if (viewer) this.fileData = viewer.fileData
+
+        this.resizeObserver = new ResizeObserver(() => this.handleResize())
+        this.resizeObserver.observe(this.viewerCanvasContainer)
     }
 
     beforeDestroy() {
@@ -399,6 +401,8 @@ export default class Viewer extends Mixins(BaseMixin) {
             clearInterval(this.scrubInterval)
             this.scrubInterval = undefined
         }
+
+        this.resizeObserver?.disconnect()
     }
 
     @Debounce(200)

--- a/src/components/panels/FarmPrinterPanel.vue
+++ b/src/components/panels/FarmPrinterPanel.vue
@@ -1,5 +1,6 @@
 <template>
     <panel
+        ref="panel"
         :icon="mdiPrinter3d"
         :title="printer_name"
         card-class="farmprinter-panel"
@@ -108,7 +109,6 @@
                 </div>
             </template>
         </v-hover>
-        <resize-observer @notify="handleResize" />
     </panel>
 </template>
 
@@ -139,10 +139,12 @@ export default class FarmPrinterPanel extends Mixins(BaseMixin, ThemeMixin, Webc
     mdiWebcamOff = mdiWebcamOff
     mdiFileOutline = mdiFileOutline
 
-    private imageHeight = 200
+    imageHeight = 200
+    resizeObserver: ResizeObserver | null = null
 
     @Prop({ type: Object, required: true }) declare printer: FarmPrinterState
     @Ref() declare readonly imageDiv: Vue
+    @Ref() declare readonly panel: Vue
 
     get printerUrl() {
         const thisUrl = window.location.href.split('/')
@@ -240,6 +242,13 @@ export default class FarmPrinterPanel extends Mixins(BaseMixin, ThemeMixin, Webc
 
     mounted() {
         this.calcImageHeight()
+
+        this.resizeObserver = new ResizeObserver(() => this.handleResize())
+        this.resizeObserver.observe(this.panel.$el)
+    }
+
+    beforeDestroy() {
+        this.resizeObserver?.disconnect()
     }
 
     calcImageHeight() {

--- a/src/components/webcams/WebcamNozzleCrosshair.vue
+++ b/src/components/webcams/WebcamNozzleCrosshair.vue
@@ -3,7 +3,6 @@
         <div class="line horizontal" :style="styleLines" />
         <div class="line vertical" :style="styleLines" />
         <div class="circle" :style="styleCircle" />
-        <resize-observer @notify="handleResize" />
     </div>
 </template>
 
@@ -12,6 +11,7 @@ import Component from 'vue-class-component'
 import { Mixins, Prop, Ref } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { GuiWebcamStateWebcam } from '@/store/gui/webcams/types'
+import { Debounce } from 'vue-debounce-decorator'
 
 @Component
 export default class WebcamWrapper extends Mixins(BaseMixin) {
@@ -19,6 +19,7 @@ export default class WebcamWrapper extends Mixins(BaseMixin) {
     @Ref() container!: HTMLDivElement
 
     clientHeight = 0
+    resizeObserver: ResizeObserver | null = null
 
     get color() {
         return this.webcam.extra_data?.nozzleCrosshairColor ?? '#ff0000'
@@ -45,8 +46,16 @@ export default class WebcamWrapper extends Mixins(BaseMixin) {
 
     mounted() {
         this.handleResize()
+
+        this.resizeObserver = new ResizeObserver(() => this.handleResize())
+        this.resizeObserver.observe(this.container)
     }
 
+    beforeDestroy() {
+        this.resizeObserver?.disconnect()
+    }
+
+    @Debounce(200)
     handleResize() {
         this.$nextTick(() => {
             this.clientHeight = this.container.clientHeight

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,10 +31,7 @@ import { use } from 'echarts/core'
 import { SVGRenderer } from 'echarts/renderers'
 import { BarChart, LineChart, PieChart } from 'echarts/charts'
 import { DatasetComponent, GridComponent, LegendComponent, TooltipComponent } from 'echarts/components'
-// vue-resize
-import 'vue-resize/dist/vue-resize.css'
-// @ts-ignore
-import VueResize from 'vue-resize'
+
 import { defaultMode } from './store/variables'
 
 Vue.config.productionTip = false
@@ -61,8 +58,6 @@ Vue.use(OverlayScrollbarsPlugin, {
 
 use([SVGRenderer, LineChart, BarChart, LegendComponent, PieChart, DatasetComponent, GridComponent, TooltipComponent])
 Vue.component('EChart', ECharts)
-
-Vue.use(VueResize)
 
 const initLoad = async () => {
     try {


### PR DESCRIPTION
## Description

This PR removes the deprecated vue-resize module and use the native ResizeObserver API instead. This should fix issues with Ocraslicer on Linux.

## Related Tickets & Documents

fixes: #2346 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
