### PR TITLE
fix(HappyHare): remove too much divider in print start dialog

### DIFF
--- a/src/components/dialogs/StartPrintDialogMmu.vue
+++ b/src/components/dialogs/StartPrintDialogMmu.vue
@@ -1,16 +1,12 @@
 <template>
-    <v-card-text class="pb-0">
-        <v-divider class="mt-4 mb-4" />
-        <p class="body-2">
-            {{ summary }}
-        </p>
+    <v-card-text>
+        <p class="body-2">{{ summary }}</p>
         <div class="text-center">
-            <v-btn color="primary" medium @click="showEditTtgMapDialog = true">
+            <v-btn color="primary" @click="showEditTtgMapDialog = true">
                 <v-icon left>{{ mdiStateMachine }}</v-icon>
                 {{ $t('Panels.MmuPanel.EditTtgMap') }}
             </v-btn>
         </div>
-        <v-divider :class="classSecondDivider" />
         <mmu-edit-ttg-map-dialog v-model="showEditTtgMapDialog" :file="file" />
     </v-card-text>
 </template>
@@ -22,7 +18,7 @@ import MmuMixin, { TOOL_GATE_BYPASS } from '@/components/mixins/mmu'
 import { FileStateGcodefile } from '@/store/files/types'
 import { mdiStateMachine } from '@mdi/js'
 
-@Component({})
+@Component
 export default class StartPrintDialogMmu extends Mixins(BaseMixin, MmuMixin) {
     mdiStateMachine = mdiStateMachine
 
@@ -33,18 +29,12 @@ export default class StartPrintDialogMmu extends Mixins(BaseMixin, MmuMixin) {
     get summary() {
         const referencedTools = this.file.referenced_tools ?? ''
         const numTools = referencedTools.length
+
         if (numTools <= 1 && this.mmuGate !== TOOL_GATE_BYPASS) {
             return this.$t('Panels.MmuPanel.StartPrintDialogMmu.SingleColor')
         }
-        return this.$t('Panels.MmuPanel.StartPrintDialogMmu.MultiColor', { numTools: numTools })
-    }
 
-    get classSecondDivider() {
-        const classes = ['mt-4']
-        classes.push(this.moonrakerComponents.includes('timelapse') ? 'mb-2' : 'mb-0')
-        return classes
+        return this.$t('Panels.MmuPanel.StartPrintDialogMmu.MultiColor', { numTools: numTools })
     }
 }
 </script>
-
-<style scoped></style>


### PR DESCRIPTION
## Description

This PR removes the divider in the StartPrintDialogMmu, which are too much after I refactored the this dialog.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

old:
<img width="473" height="404" alt="grafik" src="https://github.com/user-attachments/assets/8b94f645-eb5d-4ba2-87f1-5e49bb0fdc1d" />

new:
<img width="426" height="364" alt="grafik" src="https://github.com/user-attachments/assets/67a17852-b2c5-4808-8b4d-7310472615fd" />

## [optional] Are there any post-deployment tasks we need to perform?

<!-- note: PRs with deleted sections will be marked invalid -->
