### PR TITLE
fix(MacroPrompt): fix margin between multi line buttons

### DIFF
--- a/src/components/dialogs/MacroPromptButton.vue
+++ b/src/components/dialogs/MacroPromptButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-btn :color="color" class="mx-2" @click="sendCommand">{{ text }}</v-btn>
+    <v-btn :color="color" class="ma-2" @click="sendCommand">{{ text }}</v-btn>
 </template>
 
 <script lang="ts">

--- a/src/components/dialogs/MacroPromptButtonGroup.vue
+++ b/src/components/dialogs/MacroPromptButtonGroup.vue
@@ -1,6 +1,6 @@
 <template>
     <v-row>
-        <v-col class="text-center">
+        <v-col class="text-center py-0">
             <macro-prompt-button
                 v-for="(button, index) in children"
                 :key="'prompt_' + groupIndex + '_' + index"


### PR DESCRIPTION
## Description

This PR fix the vertical margin between multi line buttons.

## Related Tickets & Documents

- fixes #1960 

## Mobile & Desktop Screenshots/Recordings

before:
<img width="449" height="244" alt="grafik" src="https://github.com/user-attachments/assets/3df81c2e-f474-429f-96fa-51fadaf09daf" />

after:
<img width="444" height="251" alt="grafik" src="https://github.com/user-attachments/assets/826c7f5b-7f95-4b62-9fb7-6694b0633f9a" />

## [optional] Are there any post-deployment tasks we need to perform?

none
