### PR TITLE
fix(MoonrakerSensor): fix sensor name display logic

### DIFF
--- a/src/components/panels/Miscellaneous/MoonrakerSensor.vue
+++ b/src/components/panels/Miscellaneous/MoonrakerSensor.vue
@@ -42,7 +42,7 @@ export default class MoonrakerSensor extends Mixins(BaseMixin) {
     get displayName() {
         // If the friendly name is the same as the sensor name, then it hasn't been customized in the config
         // this is the fallback value in Moonraker, so we convert the sensor name to a more user-friendly format
-        if (this.sensor?.friendly_name === this.name) {
+        if (this.sensor === undefined || this.sensor?.friendly_name === this.name) {
             return this.convertName(this.name)
         }
 


### PR DESCRIPTION
## Description

This PR fix the display name from Moonraker Sensors and display the parameter `name`, when it is set in the Config. If the friendly_name is the same as the config name, then Moonraker also use the fallback name and we use the same old convertName method to format the name.

## Related Tickets & Documents

- fixes #2188 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
