### PR TITLE
refactor: remove unused PrinterStateLight type in printer store

### DIFF
--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -11,7 +11,6 @@ import {
     PrinterStateMcu,
     PrinterStateMacro,
     PrinterGetterObject,
-    PrinterStateLight,
 } from '@/store/printer/types'
 import { caseInsensitiveSort, formatFrequency, getMacroParams } from '@/plugins/helpers'
 import { RootState } from '@/store/types'

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -96,19 +96,6 @@ export interface PrinterStateFan {
     controllable: boolean
 }
 
-export interface PrinterStateLight {
-    name: string
-    type: 'led' | 'neopixel' | 'dotstar' | 'pca9533' | 'pca9632'
-    colorOrder: string
-    chainCount: number
-    initialRed: number | null
-    initialGreen: number | null
-    initialBlue: number | null
-    initialWhite: number | null
-    colorData: number[][]
-    singleChannelTarget: number | null
-}
-
 export interface PrinterStateMiscellaneous {
     name: string
     type: string


### PR DESCRIPTION
## Description

This PR just remove an unused/deprecated type from the printer vuex store.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
