### PR TITLE
style(ESlint): fix attribute order in SettingsMacrosTabExpert.vue

### DIFF
--- a/src/components/settings/SettingsMacrosTabExpert.vue
+++ b/src/components/settings/SettingsMacrosTabExpert.vue
@@ -140,8 +140,8 @@
                         handle=".handle"
                         ghost-class="ghost"
                         group="macros"
-                        @change="updateMacroOrder"
-                        :force-fallback="true">
+                        :force-fallback="true"
+                        @change="updateMacroOrder">
                         <v-row
                             v-for="(macro, index) in editGroupMacros"
                             :key="macro.name"


### PR DESCRIPTION
## Description

This PR just fix the order of attributes in SettingsMacrosTabExpert.vue, which was an ESlint issue.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
