### PR TITLE
fix(Dockerfile): remove unnecessary script copy for unprivileged image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ USER root
 RUN rm -rf /usr/share/nginx/html/*
 COPY --link --from=builder /app/.docker/nginx.conf.unprivileged  /etc/nginx/conf.d/default.conf
 COPY --link --from=builder /app/dist/ /usr/share/nginx/html/
-COPY --chmod=755 --link --from=builder /app/.docker/00-remove-ipv6-if-unavailable.sh /docker-entrypoint.d/
-
 USER nginx
 
 #


### PR DESCRIPTION
## Description

This PR fix the issue with the unprivileged image, that it couldnt start because of the 00-remove-ipv6-if-unavailable.sh script. I think this script is not really necessary for this image build, because ipv6 should be available in "half modern" Docker environment.

## Related Tickets & Documents

- fixes #2363 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
