### PR TITLE
refactor: move HistoryListPanelCol interface to centralized type

### DIFF
--- a/src/components/panels/History/HistoryListEntryJob.vue
+++ b/src/components/panels/History/HistoryListEntryJob.vue
@@ -156,7 +156,7 @@ import {
     formatFilesize,
     formatPrintTime,
 } from '@/plugins/helpers'
-import { HistoryListPanelCol } from '@/components/panels/HistoryListPanel.vue'
+import { HistoryListPanelCol } from '@/store/server/history/types'
 import HistoryListPanelNoteDialog from '@/components/dialogs/HistoryListPanelNoteDialog.vue'
 import AddBatchToQueueDialog from '@/components/dialogs/AddBatchToQueueDialog.vue'
 

--- a/src/components/panels/History/HistoryListEntryMaintenance.vue
+++ b/src/components/panels/History/HistoryListEntryMaintenance.vue
@@ -71,7 +71,7 @@ import {
     mdiNotebookCheck,
     mdiTextBoxSearch,
 } from '@mdi/js'
-import { HistoryListPanelCol } from '@/components/panels/HistoryListPanel.vue'
+import { HistoryListPanelCol } from '@/store/server/history/types'
 import { GuiMaintenanceStateEntry } from '@/store/gui/maintenance/types'
 import HistoryListPanelDetailMaintenance from '@/components/dialogs/HistoryListPanelDetailMaintenance.vue'
 

--- a/src/components/panels/History/HistoryListPanelExportCsv.vue
+++ b/src/components/panels/History/HistoryListPanelExportCsv.vue
@@ -15,7 +15,7 @@ import BaseMixin from '@/components/mixins/base'
 import { ServerHistoryStateJob } from '@/store/server/history/types'
 import { formatFilesize } from '@/plugins/helpers'
 import { mdiDatabaseExportOutline } from '@mdi/js'
-import { HistoryListPanelCol } from '@/components/panels/HistoryListPanel.vue'
+import { HistoryListPanelCol } from '@/store/server/history/types'
 import HistoryMixin from '@/components/mixins/history'
 
 @Component

--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -165,7 +165,7 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import { HistoryListRowJob, ServerHistoryStateJob } from '@/store/server/history/types'
+import { HistoryListPanelCol, HistoryListRowJob, ServerHistoryStateJob } from '@/store/server/history/types'
 import { caseInsensitiveSort, formatFilesize } from '@/plugins/helpers'
 import Panel from '@/components/ui/Panel.vue'
 import {
@@ -188,16 +188,6 @@ import HistoryMixin from '@/components/mixins/history'
 import HistoryStatsMixin from '@/components/mixins/historyStats'
 
 export type HistoryListPanelRow = HistoryListRowJob | HistoryListRowMaintenance
-
-export interface HistoryListPanelCol {
-    text: string
-    value: string
-    align: string
-    configable: boolean
-    visible: boolean
-    filterable?: boolean
-    outputType?: string
-}
 
 @Component({
     components: {

--- a/src/store/server/history/types.ts
+++ b/src/store/server/history/types.ts
@@ -90,6 +90,16 @@ export interface ServerHistoryStateAllPrintStatusEntry {
 
 export type HistoryStatsValueNames = 'jobs' | 'filament' | 'time'
 
+export interface HistoryListPanelCol {
+    text: string
+    value: string
+    align: string
+    configable: boolean
+    visible: boolean
+    filterable?: boolean
+    outputType?: string
+}
+
 export interface ServerHistoryStateJobWithCount extends ServerHistoryStateJob {
     count: number
 }


### PR DESCRIPTION
## Description

This PR moves the HistoryListPanelCol interface from HistoryListPanel.vue to @/store/server/history/types.ts to fix TypeScript import errors (TS2614). Additionally, it removes an unnecessary computed property in HistoryListEntryMaintenance.vue.

## Related Tickets & Documents

n/a

## Mobile & Desktop Screenshots/Recordings

n/a (no visual changes)
