### PR TITLE
fix: use natural sort for caseInsensitiveSort to handle numbers

### DIFF
--- a/src/plugins/helpers.ts
+++ b/src/plugins/helpers.ts
@@ -48,14 +48,20 @@ export const findDirectory = (folder: FileStateFile[], dirArray: string[]): File
     return null
 }
 
-export const caseInsensitiveSort = (values: any[], orderType: string): any[] => {
+export const caseInsensitiveSort = <T extends object>(values: T[], ...orderTypes: (keyof T)[]): T[] => {
     return values.sort((a, b) => {
-        const stringA = a[orderType].toLowerCase()
-        const stringB = b[orderType].toLowerCase()
+        for (const orderType of orderTypes) {
+            const valA: unknown = a[orderType]
+            const valB: unknown = b[orderType]
 
-        if (stringA < stringB) return -1
-        if (stringA > stringB) return 1
+            if (typeof valA !== 'string' || typeof valB !== 'string') continue
 
+            const result = valA.localeCompare(valB, undefined, {
+                numeric: true,
+                sensitivity: 'base',
+            })
+            if (result !== 0) return result
+        }
         return 0
     })
 }

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -327,23 +327,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
             }
         }
 
-        output.sort((a, b) => {
-            if (a.type < b.type) return -1
-            if (a.type > b.type) return 1
-
-            if (a.unit < b.unit) return -1
-            if (a.unit > b.unit) return 1
-
-            const nameA = a.name.toUpperCase()
-            const nameB = b.name.toUpperCase()
-
-            if (nameA < nameB) return -1
-            if (nameA > nameB) return 1
-
-            return 0
-        })
-
-        return output
+        return caseInsensitiveSort(output, 'type', 'unit', 'name')
     },
 
     getAvailableHeaters: (state) => {


### PR DESCRIPTION
## Description

This PR fixes the sorting of items with numeric suffixes (e.g., "Mmu Pre Gate 0", "Mmu Pre Gate 1", ..., "Mmu Pre Gate 10") by implementing natural sort in `caseInsensitiveSort`.

Previously, items were sorted alphabetically, causing "Mmu Pre Gate 10" to appear before "Mmu Pre Gate 2" because string comparison treats "10" < "2" (comparing character by character).

**Whats in this PR:** 
- Refactored `caseInsensitiveSort` to use `localeCompare` with `numeric: true` option
- Added TypeScript generics for better type safety and key autocompletion
- Extended function signature to support multiple sort keys via rest parameters
- Updated `getMiscellaneousSensors` getter to use the improved helper function

**Before:**
- Mmu Pre Gate 0
- Mmu Pre Gate 1
- Mmu Pre Gate 10
- Mmu Pre Gate 2
- ...

**After:**
- Mmu Pre Gate 0
- Mmu Pre Gate 1
- Mmu Pre Gate 2
- ...
- Mmu Pre Gate 10

## Related Tickets & Documents

- fixes #2365 

## Mobile & Desktop Screenshots/Recordings

n/a

## [optional] Are there any post-deployment tasks we need to perform?

n/a
