### PR TITLE
fix(AFC): use correct fallback for empty spool color in filament dialog

### DIFF
--- a/src/components/dialogs/AfcUnitLaneFilamentDialog.vue
+++ b/src/components/dialogs/AfcUnitLaneFilamentDialog.vue
@@ -71,7 +71,7 @@ export default class AfcUnitLaneFilamentDialog extends Mixins(BaseMixin, AfcMixi
     }
 
     get currentColor() {
-        return this.lane.color ?? '#000000'
+        return this.lane.color || '#000000'
     }
 
     get currentMaterial() {


### PR DESCRIPTION
## Description

This PR fixes a bug in the AFC spool details dialog where the color picker would default to red (`#FF0000`) instead of black (`#000000`) when opening the dialog for a spool without a specific color set.
The issue was caused by using the nullish coalescing operator (`??`) which only checks for `null`/`undefined`, but AFC can return an empty string (`''`) for the color property. The logical OR operator (`||`) correctly treats empty strings as falsy and applies the fallback value.

## Related Tickets & Documents

- fixes #2364 

## Mobile & Desktop Screenshots/Recordings

n/a

## [optional] Are there any post-deployment tasks we need to perform?

n/a
