### PR TITLE
feat(Preheat): add chamber temperature (M141) support to preheat gcode

### DIFF
--- a/src/store/files/getters.ts
+++ b/src/store/files/getters.ts
@@ -83,6 +83,13 @@ export const getters: GetterTree<FileState, any> = {
                 // END filter != gcode files or dirs
             })
 
+            const gcodes = Object.keys(rootState.printer.gcode.commands ?? {})
+            const preheat_gcode_objects = [
+                { name: 'first_layer_extr_temp', gcode: 'M104' },
+                { name: 'first_layer_bed_temp', gcode: 'M140' },
+                { name: 'chamber_temp', gcode: 'M141' },
+            ].filter((obj) => gcodes.includes(obj.gcode))
+
             // build gcode files array with all data in one array
             const output: FileStateGcodefile[] = []
             files.forEach((file: FileStateFile) => {
@@ -101,11 +108,6 @@ export const getters: GetterTree<FileState, any> = {
                 }
 
                 const preheat_gcode_array: string[] = []
-                const preheat_gcode_objects = [
-                    { name: 'first_layer_extr_temp', gcode: 'M104' },
-                    { name: 'first_layer_bed_temp', gcode: 'M140' },
-                ]
-
                 preheat_gcode_objects.forEach((object) => {
                     if (object.name in file && file[object.name] > 1) {
                         preheat_gcode_array.push(`${object.gcode} S${file[object.name]}`)


### PR DESCRIPTION
## Description

This PR adds chamber temperature support to the preheat gcode button. When a G-code file contains `chamber_temp` metadata (from slicers like PrusaSlicer), the preheat button will now also send `M141 S<temp>` to set the chamber temperature.

**Key implementation detail:** The M141 command is only added if Klipper reports M141 as an available G-code command. This ensures backward compatibility with printers that don't have a chamber heater macro configured. Example for a M141 macro:
```yaml
[gcode_macro M141]
gcode:
    SET_HEATER_TEMPERATURE HEATER=chamber TARGET={params.S|default(0)|float}
```

## Related Tickets & Documents

- fixes #2367 

## Mobile & Desktop Screenshots/Recordings

n/a
