### PR TITLE
fix: update page title in inactive browser tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
                 "vue-i18n": "^8.28.2",
                 "vue-inline-svg": "^2.1.3",
                 "vue-load-image": "^0.2.0",
-                "vue-meta": "^2.4.0",
                 "vue-observe-visibility": "^1.0.0",
                 "vue-property-decorator": "^9.1.2",
                 "vue-toast-notification": "^1.0.1",
@@ -5210,6 +5209,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10582,14 +10582,6 @@
             "integrity": "sha512-Y9xj4bNM3wCZFowFABEaC9pJVVhS0L8k9Ui4SbFEdYxnY/DqP4yi3vOsNENj698Zy6klOXHjJ9yEtP/z1JUOEw==",
             "peerDependencies": {
                 "vue": "^2.0.0"
-            }
-        },
-        "node_modules/vue-meta": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/vue-meta/-/vue-meta-2.4.0.tgz",
-            "integrity": "sha512-XEeZUmlVeODclAjCNpWDnjgw+t3WA6gdzs6ENoIAgwO1J1d5p1tezDhtteLUFwcaQaTtayRrsx7GL6oXp/m2Jw==",
-            "dependencies": {
-                "deepmerge": "^4.2.2"
             }
         },
         "node_modules/vue-observe-visibility": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "vue-i18n": "^8.28.2",
         "vue-inline-svg": "^2.1.3",
         "vue-load-image": "^0.2.0",
-        "vue-meta": "^2.4.0",
         "vue-observe-visibility": "^1.0.0",
         "vue-property-decorator": "^9.1.2",
         "vue-toast-notification": "^1.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,8 +46,6 @@ import { setAndLoadLocale } from './plugins/i18n'
 import TheMacroPrompt from '@/components/dialogs/TheMacroPrompt.vue'
 import { AppRoute } from '@/routes'
 
-Component.registerHooks(['metaInfo'])
-
 @Component({
     components: {
         TheMacroPrompt,
@@ -66,19 +64,12 @@ Component.registerHooks(['metaInfo'])
     },
 })
 export default class App extends Mixins(BaseMixin, ThemeMixin) {
-    public metaInfo(): any {
+    get title(): string {
         let title = this.$store.getters['getTitle']
 
         if (this.isPrinterPowerOff) title = this.$t('App.Titles.PrinterOff')
 
-        return {
-            title,
-            titleTemplate: '%s',
-        }
-    }
-
-    get title(): string {
-        return this.$store.getters['getTitle']
+        return title
     }
 
     get naviDrawer(): boolean {
@@ -186,6 +177,11 @@ export default class App extends Mixins(BaseMixin, ThemeMixin) {
 
     get progressAsFavicon() {
         return this.$store.state.gui.uiSettings.progressAsFavicon
+    }
+
+    @Watch('title', { immediate: true })
+    titleChanged(newVal: string): void {
+        document.title = newVal
     }
 
     @Watch('language')

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,8 +9,6 @@ import router from '@/plugins/router'
 import { WebSocketPlugin } from '@/plugins/webSocketClient'
 // vue-observe-visibility
 import { ObserveVisibility } from 'vue-observe-visibility'
-//vue-meta
-import VueMeta from 'vue-meta'
 //vue-load-image
 import VueLoadImage from 'vue-load-image'
 //vue-toast-notifications
@@ -37,8 +35,6 @@ import { defaultMode } from './store/variables'
 Vue.config.productionTip = false
 
 Vue.directive('observe-visibility', ObserveVisibility)
-
-Vue.use(VueMeta)
 
 Vue.component('VueLoadImage', VueLoadImage)
 


### PR DESCRIPTION
## Description

This PR fixes the page title not updating in inactive browser tabs (especially in Firefox). The issue was caused by `vue-meta` not receiving reactivity updates when the browser throttles JavaScript execution in background tabs.
The fix removes `vue-meta` entirely and replaces it with a direct `document.title` assignment via a Vue `@Watch` decorator. This approach is consistent with how the favicon is already updated and works reliably in inactive tabs.

**Changes:**
- Remove `vue-meta` dependency from `package.json`
- Remove `vue-meta` import and plugin registration from `main.ts`
- Replace `metaInfo()` method with a `@Watch('title')` that sets `document.title` directly in `App.vue`

## Related Tickets & Documents

- Fixes #1251

## Mobile & Desktop Screenshots/Recordings

No visual changes - this fix affects the browser tab title behavior only.

## [optional] Are there any post-deployment tasks we need to perform?

None
