### PR TITLE
style: run prettier and fix format in MmuFilamentStatus.vue

### DIFF
--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -19,7 +19,13 @@
                 <rect x="3" y="0" width="30" height="40" rx="3" ry="3" fill="none" stroke-width="1.5" />
                 <path d="M-15 -4 L-6 0 L-15 4 Z" stroke-width="1" fill-opacity="0.6" />
                 <path d="M8 40 L 28 40" stroke-width="4" />
-                <text v-if="hasFilamentProportionalSensor" x="-22" y="4" font-size="11px" text-anchor="end" style="fill: var(--color-outline)">
+                <text
+                    v-if="hasFilamentProportionalSensor"
+                    x="-22"
+                    y="4"
+                    font-size="11px"
+                    text-anchor="end"
+                    style="fill: var(--color-outline)">
                     {{ syncFeedbackPistonText }}
                 </text>
             </g>


### PR DESCRIPTION
## Description

This PR just fix the syntax format with npm run format (prettier).

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
