### PR TITLE
fix: exclude tmp data from backup/restore mainsail settings

### DIFF
--- a/src/components/mixins/gcodefiles.ts
+++ b/src/components/mixins/gcodefiles.ts
@@ -19,7 +19,7 @@ export default class GcodefilesMixin extends Vue {
     }
 
     set search(value: string) {
-        this.$store.dispatch('gui/saveSettingWithoutUpload', { name: 'view.gcodefiles.search', value })
+        this.$store.dispatch('gui/saveSetting', { name: 'view.gcodefiles.search', value })
     }
 
     get currentPath() {
@@ -30,7 +30,7 @@ export default class GcodefilesMixin extends Vue {
     }
 
     set currentPath(newVal) {
-        this.$store.dispatch('gui/saveSettingWithoutUpload', { name: 'view.gcodefiles.currentPath', value: newVal })
+        this.$store.dispatch('gui/saveSetting', { name: 'view.gcodefiles.currentPath', value: newVal })
     }
 
     get showHiddenFiles() {
@@ -263,7 +263,7 @@ export default class GcodefilesMixin extends Vue {
     }
 
     set selectedFiles(newVal) {
-        this.$store.dispatch('gui/saveSettingWithoutUpload', { name: 'view.gcodefiles.selectedFiles', value: newVal })
+        this.$store.dispatch('gui/saveSetting', { name: 'view.gcodefiles.selectedFiles', value: newVal })
     }
 
     existsFilename(name: string) {

--- a/src/components/panels/HistoryListPanel.vue
+++ b/src/components/panels/HistoryListPanel.vue
@@ -480,7 +480,7 @@ export default class HistoryListPanel extends Mixins(BaseMixin, HistoryMixin, Hi
     }
 
     set selectedJobsTable(newVal) {
-        this.$store.dispatch('gui/saveSettingWithoutUpload', { name: 'view.history.selectedJobs', value: newVal })
+        this.$store.dispatch('gui/saveSetting', { name: 'view.history.selectedJobs', value: newVal })
     }
 
     refreshHistory() {

--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -673,7 +673,7 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
     }
 
     set blockFileUpload(newVal) {
-        this.$store.dispatch('gui/saveSettingWithoutUpload', { name: 'view.blockFileUpload', value: newVal })
+        this.$store.dispatch('gui/saveSetting', { name: 'view.blockFileUpload', value: newVal })
     }
 
     get toolbarButtons() {
@@ -800,7 +800,7 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
     }
 
     set selectedFiles(newVal) {
-        this.$store.dispatch('gui/saveSettingWithoutUpload', { name: 'view.configfiles.selectedFiles', value: newVal })
+        this.$store.dispatch('gui/saveSetting', { name: 'view.configfiles.selectedFiles', value: newVal })
     }
 
     get countPerPage() {
@@ -875,7 +875,7 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
     }
 
     set root(newVal) {
-        this.$store.dispatch('gui/saveSettingWithoutUpload', { name: 'view.configfiles.rootPath', value: newVal })
+        this.$store.dispatch('gui/saveSetting', { name: 'view.configfiles.rootPath', value: newVal })
     }
 
     get currentPath() {
@@ -885,7 +885,7 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
     set currentPath(newVal) {
         this.selectedFiles = []
 
-        this.$store.dispatch('gui/saveSettingWithoutUpload', { name: 'view.configfiles.currentPath', value: newVal })
+        this.$store.dispatch('gui/saveSetting', { name: 'view.configfiles.currentPath', value: newVal })
     }
 
     get deleteSelectedDialogText(): string {

--- a/src/components/panels/Timelapse/TimelapseFilesPanel.vue
+++ b/src/components/panels/Timelapse/TimelapseFilesPanel.vue
@@ -579,7 +579,7 @@ export default class TimelapseFilesPanel extends Mixins(BaseMixin) {
     }
 
     set currentPath(newVal) {
-        this.$store.dispatch('gui/saveSettingWithoutUpload', { name: 'view.timelapse.currentPath', value: newVal })
+        this.$store.dispatch('gui/saveSetting', { name: 'view.timelapse.currentPath', value: newVal })
     }
 
     get selectedFiles() {
@@ -587,7 +587,7 @@ export default class TimelapseFilesPanel extends Mixins(BaseMixin) {
     }
 
     set selectedFiles(newVal) {
-        this.$store.dispatch('gui/saveSettingWithoutUpload', { name: 'view.timelapse.selectedFiles', value: newVal })
+        this.$store.dispatch('gui/saveSetting', { name: 'view.timelapse.selectedFiles', value: newVal })
     }
 
     get deleteSelectedDialogText(): string {

--- a/src/plugins/helpers.ts
+++ b/src/plugins/helpers.ts
@@ -504,3 +504,20 @@ export function colorsMatch(color1: string, color2: string, tolerance = 0): bool
         Math.abs(rgb1.b - rgb2.b) <= tolerance
     )
 }
+
+/**
+ * Deletes a nested property from an object using a dot-separated path.
+ */
+export const deletePath = (obj: any, path: string) => {
+    const parts = path.split('.')
+    const last = parts.pop()
+    if (!last) return
+
+    let current = obj
+    for (const part of parts) {
+        if (current[part] === undefined) return
+        current = current[part]
+    }
+
+    if (current && typeof current === 'object') delete current[last]
+}

--- a/src/plugins/helpers.ts
+++ b/src/plugins/helpers.ts
@@ -507,6 +507,12 @@ export function colorsMatch(color1: string, color2: string, tolerance = 0): bool
 
 /**
  * Deletes a nested property from an object using a dot-separated path.
+ *
+ * The object is mutated in place. If any part of the path does not exist,
+ * the function returns without making changes.
+ *
+ * @param obj - The object to modify.
+ * @param path - Dot-separated path to the property to delete (e.g. "a.b.c").
  */
 export const deletePath = (obj: any, path: string) => {
     const parts = path.split('.')

--- a/src/store/gui/actions.ts
+++ b/src/store/gui/actions.ts
@@ -3,7 +3,8 @@ import { ActionTree } from 'vuex'
 import { GuiState, GuiStateLayoutoption } from '@/store/gui/types'
 import { RootState } from '@/store/types'
 import { getDefaultState } from './index'
-import { themeDir } from '@/store/variables'
+import { excludeKeys, themeDir } from '@/store/variables'
+import { deletePath } from '@/plugins/helpers'
 
 export const actions: ActionTree<GuiState, RootState> = {
     reset({ commit, dispatch }) {
@@ -173,16 +174,13 @@ export const actions: ActionTree<GuiState, RootState> = {
 
     saveSetting({ commit }, payload) {
         commit('saveSetting', payload)
+        if (excludeKeys.includes(payload.name)) return
 
         Vue.$socket.emit('server.database.post_item', {
             namespace: 'mainsail',
             key: payload.name,
             value: payload.value,
         })
-    },
-
-    saveSettingWithoutUpload({ commit }, payload) {
-        commit('saveSetting', payload)
     },
 
     updateSettings(_, payload) {
@@ -316,6 +314,12 @@ export const actions: ActionTree<GuiState, RootState> = {
                 if (objects?.result?.value) backup[key] = { ...objects?.result?.value }
             } else if (key in mainsailDb) {
                 backup[key] = { ...mainsailDb[key] }
+
+                excludeKeys.forEach((excludeKey) => {
+                    if (!excludeKey.startsWith(key + '.')) return
+
+                    deletePath(backup[key], excludeKey.substring(key.length + 1))
+                })
             }
         }
 

--- a/src/store/gui/actions.ts
+++ b/src/store/gui/actions.ts
@@ -315,11 +315,11 @@ export const actions: ActionTree<GuiState, RootState> = {
             } else if (key in mainsailDb) {
                 backup[key] = { ...mainsailDb[key] }
 
-                excludeKeys.forEach((excludeKey) => {
-                    if (!excludeKey.startsWith(key + '.')) return
-
-                    deletePath(backup[key], excludeKey.substring(key.length + 1))
-                })
+                excludeKeys
+                    .filter((excludeKey) => excludeKey.startsWith(key + '.'))
+                    .forEach((excludeKey) => {
+                        deletePath(backup[key], excludeKey.substring(key.length + 1))
+                    })
             }
         }
 

--- a/src/store/variables.ts
+++ b/src/store/variables.ts
@@ -154,6 +154,23 @@ export const genericLogfiles = ['klippy', 'moonraker', 'crowsnest', 'mmu', 'sona
 export const rolloverLogfiles = ['klipper', 'moonraker']
 
 /*
+ * List of keys that should not be saved to Moonraker DB
+ * and are excluded when backup/restore settings
+ */
+export const excludeKeys = [
+    'view.timelapse.currentPath',
+    'view.timelapse.selectedFiles',
+    'view.history.selectedJobs',
+    'view.blockFileUpload',
+    'view.configfiles.selectedFiles',
+    'view.configfiles.rootPath',
+    'view.configfiles.currentPath',
+    'view.gcodefiles.search',
+    'view.gcodefiles.currentPath',
+    'view.gcodefiles.selectedFiles',
+]
+
+/*
  * List of all Themes
  */
 export const themes: Theme[] = [


### PR DESCRIPTION
## Description

This PR fixes an issue where transient UI states (such as selected items in lists, current paths, search queries, etc.) were being saved to the Moonraker database and subsequently included in backups. 

Restoring these backups caused consistency issues. Specifically, as reported, if `view.history.selectedJobs` was included in a backup, restoring it would update the history totals with "ghost" entries that did not exist in the actual history list, making it impossible to correct the statistics.

**Changes:**
- Introduced `excludeKeys` in `@/store/variables` to define keys that should strictly remain local-only.
- Updated the `gui/saveSetting` action to check this exclusion list and skip the Moonraker upload (socket emission) for matching keys.
- Removed the now redundant `gui/saveSettingWithoutUpload` action and refactored all its usages to `gui/saveSetting`.
- Updated `backupMoonrakerDB` to actively filter out these keys during the export process. This ensures that even if a user has "polluted" data in their current database, the generated backup will be clean.

## Related Tickets & Documents

- fixes #2390 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
