### PR TITLE
fix(ConfigFilesPanel): fix translation key for delete dialog titles

### DIFF
--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -433,13 +433,13 @@
             @action="deleteDirectoryAction" />
         <confirmation-dialog
             v-model="deleteDialog"
-            :title="$t('Machine.ConfigFilesPanel.Delete')"
+            :title="$t('Buttons.Delete')"
             :text="$t('Machine.ConfigFilesPanel.DeleteSingleFileQuestion', { name: contextMenu.item.filename })"
             :action-button-text="$t('Buttons.Delete')"
             @action="removeFile" />
         <confirmation-dialog
             v-model="deleteSelectedDialog"
-            :title="$t('Machine.ConfigFilesPanel.Delete')"
+            :title="$t('Buttons.Delete')"
             :text="deleteSelectedDialogText"
             :action-button-text="$t('Buttons.Delete')"
             @action="deleteSelectedFiles" />


### PR DESCRIPTION
## Description

This PR fix two missing title translations in the ConfigFilesPanel. With the rework of all dialogs, I delete these translation keys and now I replaced it with the generic button translations.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
