### PR TITLE
refactor: update start-print-dialog to use v-model

### DIFF
--- a/src/components/dialogs/StartPrintDialog.vue
+++ b/src/components/dialogs/StartPrintDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <v-dialog
-        v-model="bool"
+        v-model="showDialog"
         :max-width="400"
         content-class="overflow-x-hidden"
         @click:outside="closeDialog"
@@ -34,7 +34,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop } from 'vue-property-decorator'
+import { Component, Mixins, Prop, VModel } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { FileStateGcodefile } from '@/store/files/types'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
@@ -48,7 +48,7 @@ import AfcMixin from '@/components/mixins/afc'
 export default class StartPrintDialog extends Mixins(BaseMixin, AfcMixin) {
     mdiPrinter3d = mdiPrinter3d
 
-    @Prop({ required: true, default: false }) readonly bool!: boolean
+    @VModel({ type: Boolean }) showDialog!: boolean
     @Prop({ required: true, default: '' }) readonly currentPath!: string
     @Prop({ required: true }) readonly file!: FileStateGcodefile
 
@@ -88,7 +88,7 @@ export default class StartPrintDialog extends Mixins(BaseMixin, AfcMixin) {
     }
 
     closeDialog() {
-        this.$emit('closeDialog')
+        this.showDialog = false
     }
 }
 </script>

--- a/src/components/panels/Gcodefiles/GcodefilesPanelTableRowFile.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelTableRowFile.vue
@@ -108,11 +108,7 @@
                 </v-list-item>
             </v-list>
         </v-menu>
-        <start-print-dialog
-            :bool="showStartPrintDialog"
-            :file="item"
-            :current-path="currentPath"
-            @closeDialog="showStartPrintDialog = false" />
+        <start-print-dialog v-model="showStartPrintDialog" :file="item" :current-path="currentPath" />
         <add-batch-to-queue-dialog v-model="showAddBatchToQueueDialog" :filename="item.full_filename" />
         <gcodefiles-rename-file-dialog v-model="showRenameFileDialog" :item="item" />
         <gcodefiles-duplicate-file-dialog v-model="showDuplicateFileDialog" :item="item" />

--- a/src/components/panels/Status/GcodefilesEntry.vue
+++ b/src/components/panels/Status/GcodefilesEntry.vue
@@ -64,11 +64,7 @@
                 </v-list-item>
             </v-list>
         </v-menu>
-        <start-print-dialog
-            :bool="showPrintDialog"
-            :file="item"
-            current-path=""
-            @closeDialog="showPrintDialog = false" />
+        <start-print-dialog v-model="showPrintDialog" :file="item" current-path="" />
         <add-batch-to-queue-dialog v-model="showAddBatchToQueueDialog" :filename="filename" />
         <gcodefiles-rename-file-dialog v-model="showRenameFileDialog" :item="item" />
         <confirmation-dialog


### PR DESCRIPTION
## Description

This PR just update the start print dialog to use v-model instead of a prop. Looks like i missed this dialog in #2372 .

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the print dialog's internal state management implementation across the application for improved code consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->