### PR TITLE
fix: correct month output in date to start from 1 instead 0

### DIFF
--- a/src/components/mixins/base.ts
+++ b/src/components/mixins/base.ts
@@ -232,10 +232,10 @@ export default class BaseMixin extends Vue {
                     output.push(`${tmp?.getDate()}`)
                     break
                 case 'mm':
-                    output.push((tmp?.getMonth() ?? 0).toString().padStart(2, '0'))
+                    output.push(((tmp?.getMonth() ?? 0) + 1).toString().padStart(2, '0'))
                     break
                 case 'm':
-                    output.push(`${tmp?.getMonth() ?? 0}`)
+                    output.push(`${(tmp?.getMonth() ?? 0) + 1}`)
                     break
                 case 'yyyy':
                     output.push(`${tmp?.getFullYear()}`)


### PR DESCRIPTION
## Description

This PR fix the month formatting in all custom formats. the getMonth() function start the months with 0 instead of 1. so Jan = 0 and Feb = 1. So we had to +1 to have the correct output number.

## Related Tickets & Documents

 fixes #2407

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed month handling in date formatting to properly display months as 1-12 instead of 0-11, ensuring dates are presented correctly across supported formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->