### PR TITLE
fix(Temperature): dynamic input width based on max temp digits

### DIFF
--- a/src/components/inputs/TemperatureInput.vue
+++ b/src/components/inputs/TemperatureInput.vue
@@ -9,9 +9,10 @@
                 outlined
                 hide-details
                 hide-spin-buttons
-                class="_temp-input pr-1"
+                class="_temp-input"
+                :style="inputStyle"
                 @blur="value = target"
-                @focus="$event.target.select()"></v-text-field>
+                @focus="$event.target.select()" />
         </form>
         <v-menu v-if="presets" :offset-y="true" left title="Preheat">
             <template #activator="{ on, attrs }">
@@ -60,7 +61,7 @@ export default class TemperatureInput extends Mixins(BaseMixin, ControlMixin) {
     mdiFire = mdiFire
     mdiMenuDown = mdiMenuDown
 
-    private value: any = 0
+    value: any = 0
 
     @Prop({ type: String, required: true }) declare readonly name: string
     @Prop({ type: Number, required: true, default: 0 }) declare readonly target: number
@@ -69,6 +70,20 @@ export default class TemperatureInput extends Mixins(BaseMixin, ControlMixin) {
     @Prop({ type: String, required: true }) declare readonly command: string
     @Prop({ type: String, required: true }) declare readonly attributeName: string
     @Prop({ type: Array, default: [] }) declare presets: number[]
+    @Prop({ type: Number, default: 3 }) declare readonly inputDigits: number
+
+    get inputStyle() {
+        const PER_DIGIT = 10
+        const WIDTH_C_GRAD = 21
+        const PADDING = 20
+        const SPACE_FOR_DECIMAL = 10
+
+        const width = this.inputDigits * PER_DIGIT + WIDTH_C_GRAD + PADDING + SPACE_FOR_DECIMAL
+
+        return {
+            width: `${width}px`,
+        }
+    }
 
     setTemps(): void {
         if (typeof this.value === 'object') this.value = this.value.value ?? 0
@@ -103,11 +118,6 @@ export default class TemperatureInput extends Mixins(BaseMixin, ControlMixin) {
 </script>
 
 <style scoped>
-._temp-input {
-    min-width: 4.2rem;
-    max-width: 5rem;
-}
-
 ._temp-input >>> .v-input__slot {
     min-height: 1rem !important;
     padding-left: 8px !important;

--- a/src/components/panels/Temperature/TemperaturePanelList.vue
+++ b/src/components/panels/Temperature/TemperaturePanelList.vue
@@ -25,6 +25,7 @@
                         v-for="objectName in heaterObjects"
                         :key="objectName"
                         :object-name="objectName"
+                        :input-digits="inputFieldDigits"
                         :is-responsive-mobile="el.is.mobile ?? false" />
                     <temperature-panel-list-item-nevermore
                         v-for="objectName in nevermoreObjects"
@@ -121,6 +122,18 @@ export default class TemperaturePanelList extends Mixins(BaseMixin) {
         return this.$store.state.printer?.configfile?.settings ?? {}
     }
 
+    get maxTemperatureSetting() {
+        return this.heaterObjects.reduce((maxTemp, heaterObject) => {
+            const settingObject = this.settings[heaterObject.toLowerCase()] ?? {}
+            const max_temp = settingObject.max_temp ?? 0
+            return Math.max(maxTemp, max_temp)
+        }, 0)
+    }
+
+    get inputFieldDigits() {
+        return this.maxTemperatureSetting.toString().length
+    }
+
     checkMcuHostSensor(fullName: string) {
         const settingsObject = this.settings[fullName.toLowerCase()] ?? {}
         const sensor_type = settingsObject.sensor_type ?? ''
@@ -182,6 +195,7 @@ export default class TemperaturePanelList extends Mixins(BaseMixin) {
 }
 
 .temperature-panel-table ::v-deep .target {
-    width: 140px;
+    width: 1px;
+    white-space: nowrap;
 }
 </style>

--- a/src/components/panels/Temperature/TemperaturePanelList.vue
+++ b/src/components/panels/Temperature/TemperaturePanelList.vue
@@ -125,8 +125,9 @@ export default class TemperaturePanelList extends Mixins(BaseMixin) {
     get maxTemperatureSetting() {
         return this.heaterObjects.reduce((maxTemp, heaterObject) => {
             const settingObject = this.settings[heaterObject.toLowerCase()] ?? {}
-            const max_temp = settingObject.max_temp ?? 0
-            return Math.max(maxTemp, max_temp)
+            const maxTempSetting = Number(settingObject.max_temp ?? 0)
+
+            return Math.max(maxTemp, maxTempSetting)
         }, 0)
     }
 

--- a/src/components/panels/Temperature/TemperaturePanelList.vue
+++ b/src/components/panels/Temperature/TemperaturePanelList.vue
@@ -132,7 +132,10 @@ export default class TemperaturePanelList extends Mixins(BaseMixin) {
     }
 
     get inputFieldDigits() {
-        return this.maxTemperatureSetting.toString().length
+        const MIN_INPUT_DIGITS = 3
+        const digits = this.maxTemperatureSetting.toString().length
+
+        return Math.max(MIN_INPUT_DIGITS, digits)
     }
 
     checkMcuHostSensor(fullName: string) {

--- a/src/components/panels/Temperature/TemperaturePanelListItem.vue
+++ b/src/components/panels/Temperature/TemperaturePanelListItem.vue
@@ -46,6 +46,7 @@
                 :min_temp="min_temp"
                 :max_temp="max_temp"
                 :command="command"
+                :input-digits="inputDigits"
                 :attribute-name="commandAttributeName" />
         </td>
         <temperature-panel-list-item-edit
@@ -98,6 +99,7 @@ export default class TemperaturePanelListItem extends Mixins(BaseMixin) {
 
     @Prop({ type: String, required: true }) readonly objectName!: string
     @Prop({ type: Boolean, required: true }) readonly isResponsiveMobile!: boolean
+    @Prop({ type: Number, default: 3 }) readonly inputDigits!: number
 
     showEditDialog = false
     showContextMenu = false


### PR DESCRIPTION
## Description

This PR fix the Temperature input field width on the max temp digits from the "hottest" heater.

## Related Tickets & Documents

fixes #2404

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Temperature input fields now dynamically adjust width based on their content for improved layout responsiveness; target column layout prevents wrapping.

* **New Features**
  * Input width is now configurable (controls number of digits shown) and flows through the temperature panels so fields stay consistently sized across the UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->