### PR TITLE
fix: selected files single file download without zip

### DIFF
--- a/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
@@ -104,6 +104,12 @@ export default class GcodefilesPanelHeader extends Mixins(BaseMixin, GcodefilesM
     }
 
     downloadSelectedFiles() {
+        if (this.selectedFiles.length === 1) {
+            const filepath = `${this.currentPath}/${escapePath(this.selectedFiles[0].filename)}`
+            const href = `${this.apiUrl}/server/files/gcodes${escapePath(filepath)}`
+            window.open(href)
+        }
+
         let items: string[] = []
 
         const addElementToItems = (absolutPath: string, directory: FileStateFile[]) => {

--- a/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
@@ -108,6 +108,7 @@ export default class GcodefilesPanelHeader extends Mixins(BaseMixin, GcodefilesM
             const filepath = `${this.currentPath}/${this.selectedFiles[0].filename}`
             const href = `${this.apiUrl}/server/files/gcodes${escapePath(filepath)}`
             window.open(href)
+            return
         }
 
         let items: string[] = []

--- a/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
@@ -105,7 +105,7 @@ export default class GcodefilesPanelHeader extends Mixins(BaseMixin, GcodefilesM
 
     downloadSelectedFiles() {
         if (this.selectedFiles.length === 1) {
-            const filepath = `${this.currentPath}/${escapePath(this.selectedFiles[0].filename)}`
+            const filepath = `${this.currentPath}/${this.selectedFiles[0].filename}`
             const href = `${this.apiUrl}/server/files/gcodes${escapePath(filepath)}`
             window.open(href)
         }

--- a/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
@@ -108,6 +108,8 @@ export default class GcodefilesPanelHeader extends Mixins(BaseMixin, GcodefilesM
             const filepath = `${this.currentPath}/${this.selectedFiles[0].filename}`
             const href = `${this.apiUrl}/server/files/gcodes${escapePath(filepath)}`
             window.open(href)
+
+            this.selectedFiles = []
             return
         }
 

--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -967,13 +967,24 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
         this.contextMenu.shown = true
     }
 
-    downloadFile() {
-        const filename = this.absolutePath + '/' + this.contextMenu.item.filename
-        const href = `${this.apiUrl}/server/files${escapePath(filename)}`
+    private startDownloadFile(filename: string) {
+        const filepath = `${this.absolutePath}/${filename}`
+        const href = `${this.apiUrl}/server/files${escapePath(filepath)}`
         window.open(href)
     }
 
+    downloadFile() {
+        this.startDownloadFile(this.contextMenu.item.filename)
+        this.contextMenu.shown = false
+    }
+
     async downloadSelectedFiles() {
+        if (this.selectedFiles.length === 1) {
+            this.startDownloadFile(this.selectedFiles[0].filename)
+            this.selectedFiles = []
+            return
+        }
+
         let items: string[] = []
 
         const addElementToItems = async (absolutPath: string, directory: FileStateFile[]) => {


### PR DESCRIPTION
## Description

This PR improve the selected files download in Gcodefiles & Configfiles to just download the file and don't zip it.

## Related Tickets & Documents

fixes #2402 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved single-file download behavior for G-code and config files: selecting one file now triggers a direct download (opens in a new window) and clears the selection instead of packaging it in a zip.
  * Context menu now closes after initiating a download.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->