### PR TITLE
fix: format timestamp for selected files download

### DIFF
--- a/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesPanelHeader.vue
@@ -69,7 +69,7 @@ import BaseMixin from '@/components/mixins/base'
 import GcodefilesMixin from '@/components/mixins/gcodefiles'
 import { mdiCloudDownload, mdiDelete, mdiFolderPlus, mdiMagnify, mdiRefresh, mdiUpload } from '@mdi/js'
 import { FileStateFile } from '@/store/files/types'
-import { escapePath } from '@/plugins/helpers'
+import { escapePath, generateTimestamp } from '@/plugins/helpers'
 import ConfirmationDialog from '@/components/dialogs/ConfirmationDialog.vue'
 import { validGcodeExtensions } from '@/store/variables'
 
@@ -121,12 +121,10 @@ export default class GcodefilesPanelHeader extends Mixins(BaseMixin, GcodefilesM
         }
 
         addElementToItems('gcodes/' + this.currentPath, this.selectedFiles)
-        const date = new Date()
-        const timestamp = `${date.getFullYear()}${date.getMonth()}${date.getDate()}-${date.getHours()}${date.getMinutes()}${date.getSeconds()}`
 
         this.$socket.emit(
             'server.files.zip',
-            { items, dest: `config/gcodes-${timestamp}.zip` },
+            { items, dest: `config/gcodes-${generateTimestamp()}.zip` },
             { action: 'files/downloadZip', loading: 'gcodeDownloadZip' }
         )
 

--- a/src/components/panels/Machine/ConfigFilesPanel.vue
+++ b/src/components/panels/Machine/ConfigFilesPanel.vue
@@ -466,7 +466,7 @@
 import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import ThemeMixin from '@/components/mixins/theme'
-import { escapePath, formatFilesize, sortFiles } from '@/plugins/helpers'
+import { escapePath, formatFilesize, generateTimestamp, sortFiles } from '@/plugins/helpers'
 import { FileStateFile, FileStateGcodefile } from '@/store/files/types'
 import axios from 'axios'
 import Panel from '@/components/ui/Panel.vue'
@@ -992,17 +992,9 @@ export default class ConfigFilesPanel extends Mixins(BaseMixin, ThemeMixin) {
 
         await addElementToItems(this.absolutePath, this.selectedFiles)
 
-        const date = new Date()
-        const month = (date.getMonth() + 1).toString().padStart(2, '0')
-        const day = date.getDate().toString().padStart(2, '0')
-        const hours = date.getHours().toString().padStart(2, '0')
-        const minutes = date.getMinutes().toString().padStart(2, '0')
-        const seconds = date.getSeconds().toString().padStart(2, '0')
-        const timestamp = `${date.getFullYear()}${month}${day}-${hours}${minutes}${seconds}`
-
         this.$socket.emit(
             'server.files.zip',
-            { items, dest: `config/${this.root}-${timestamp}.zip` },
+            { items, dest: `config/${this.root}-${generateTimestamp()}.zip` },
             { action: 'files/downloadZip', loading: 'configDownloadZip' }
         )
 

--- a/src/plugins/helpers.ts
+++ b/src/plugins/helpers.ts
@@ -527,3 +527,21 @@ export const deletePath = (obj: any, path: string) => {
 
     if (current && typeof current === 'object') delete current[last]
 }
+
+/**
+ * Generates a timestamp string in the format `YYYYMMDD-HHMMSS`.
+ *
+ * @param date - Optional date object. Defaults to current date/time.
+ * @returns Formatted timestamp string (e.g., `20260130-070253`)
+ *
+ * @example
+ * generateTimestamp() // '20260130-070253' (current time)
+ * generateTimestamp(new Date('2025-12-25T10:30:00')) // '20251225-103000'
+ */
+export function generateTimestamp(date: Date = new Date()): string {
+    const pad = (n: number) => n.toString().padStart(2, '0')
+    const dateString = `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}`
+    const timeString = `${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
+
+    return `${dateString}-${timeString}`
+}


### PR DESCRIPTION
## Description

This PR fix the timestamp generation/formatting for selected files download + use 1 generic function instead of 2 different inline generations.

In Gcodefiles was also a bug with a wrong month number, because of getMonth returns 0 for January instead of 1. I also added a pad function so the complete date will also be with 2 digits per number.

## Related Tickets & Documents

none

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored timestamp generation for downloaded files to use a centralized utility function, improving consistency across file download operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->