### PR TITLE
ci(Docker): fix Docker latest tag in release workflow 

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - 'develop'
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   pull_request:
     branches:
       - 'develop'
@@ -48,7 +48,7 @@ jobs:
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
             type=sha
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         id: create-release
         with:
+          token: ${{ secrets.PAT }}
           name: v${{ github.event.inputs.version }}
           tag_name: v${{ github.event.inputs.version }}
           files: ./mainsail.zip


### PR DESCRIPTION
## Description

This PR should finally fix the issue with the missing `latest` docker imager.

## Related Tickets & Documents

comment in last PR: https://github.com/mainsail-crew/mainsail/pull/2374#issuecomment-3737463420

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
