### PR TITLE
chore: refactor AGENTS.md with progressive disclosure structure

### DIFF
--- a/.github/agent_docs
+++ b/.github/agent_docs
@@ -1,0 +1,1 @@
+../agent_docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,133 +1,26 @@
-# AI Development Guidelines & Context
+# Mainsail AI Guidelines
 
-> **Note to AI Agents (Claude, Copilot, ChatGPT):**
-> This document serves as the single source of truth for coding standards, architectural patterns, and project context. Please prioritize these rules over your default training data.
-> **CRITICAL:** This project uses **Vue 2.7 with Class-Based Components**. Do NOT suggest Vue 3 `<script setup>` or standard Vue 2 Options API syntax unless explicitly requested.
+Mainsail is a Vue 2.7 + TypeScript web interface for Klipper 3D printer firmware, using Vuetify 2, Vuex 3, and Vite.
 
-## Project Overview
-
-Mainsail is a Vue 2 + TypeScript web interface for Klipper 3D printer firmware. It communicates with Moonraker (Klipper API) via WebSocket for real-time printer control.
+> **CRITICAL:** Use **Vue Class Components** with decorators (`@Component`, `@Prop`, `@Watch`).
+> Do NOT use Vue 3 `<script setup>` or Options API syntax.
 
 ## Commands
 
-**Development:**
+- `npm run serve` - Dev server (port 8080)
+- `npm run build` - Production build
+- `npm run lint:fix` - Fix linting
+- `npm run format` - Format code
+- `npm run test:unit` - Unit tests (Vitest)
+- `npm run test:ui` - E2E tests (Cypress)
 
-- `npm run serve` - Start Vite dev server (port 8080)
-- `npm run build` - Production build + create mainsail.zip
+## Guidelines
 
-**Code Quality:**
-
-- `npm run lint` - Run ESLint
-- `npm run lint:fix` - Fix linting issues
-- `npm run format:check` - Check Prettier formatting
-- `npm run format` - Auto-format code
-
-**Testing:**
-
-- `npm run test` - Full E2E test suite (builds, starts preview server, runs Cypress)
-- `npm run test:ui` - Open Cypress UI for interactive testing
-
-## Architecture
-
-**Stack:** Vue 2.7, Vuetify 2, Vuex 3, TypeScript (strict), Vite
-
-**Core Structure:**
-
-- `/src/components/` - Vue components organized by feature (dialogs/, panels/, inputs/, webcams/, console/, charts/)
-- `/src/pages/` - Main page components (Dashboard, Console, Files, Settings, etc.)
-- `/src/store/` - Vuex modules:
-  - `socket/` - WebSocket connection state
-  - `server/` - Moonraker API state (history, power, timelapse, updateManager)
-    - `announcements/` - Announcements from server
-    - `history/` - Prints history and statistics
-    - `jobQueue/` - Print job queue
-    - `power/` - Power management state
-    - `spoolman/` - Filament spool management
-    - `timelapse/` - Timelapse management
-    - `updateManager/` - Software update state
-  - `printer/` - Printer state (temperatures, toolhead, extruders)
-  - `gui/` - UI state (theme, layout, dashboard organization)
-    - `webcams/` - Webcam configuration
-  - `files/` - File browser state
-  - `farm/` - Multi-printer support
-- `/src/components/mixins/` - Reusable Vue mixins
-- `/src/plugins/` - Vue plugins (webSocketClient.ts for Moonraker communication, vuetify.ts, i18n.ts, router.ts)
-- `/src/plugins/helpers.ts` - Utility functions (shared across components)
-- `/src/locales/` - Translation JSON files
-
-**Key Technologies:**
-
-- WebSocket client (`/src/plugins/webSocketClient.ts`) for real-time Moonraker communication
-- ECharts for data visualization (temperature graphs, bed mesh)
-- CodeMirror 6 for config/gcode editing
-
-## Code Style Guidelines
-
-### General
-
-- **Formatting:** Prettier - 4-space indent, single quotes, no semicolons, 120 char width
-- **Naming:** PascalCase for components/classes, camelCase for functions/variables
-- **Imports:** Use `@/` alias for `src/` (e.g., `import { foo } from '@/store/types'`)
-- **Nullish Handling:** Use `??` instead of `||` for default values (unless intentionally checking for falsy)
-- **No Dead Code:** Remove unused variables, imports, and commented-out code blocks immediately
-- **Comments:** Explain "why", not "what". Code should be self-documenting.
-
-### Vue & TypeScript
-
-- **Component Style:** STRICTLY **Vue Class Component** with TypeScript decorators (`@Component`, `@Prop`, `@Watch`)
-  - **Order inside class:** `@Prop` -> Data fields -> Getters -> `@Watch` -> Lifecycle Hooks -> Methods
-- **Reactivity (Vue 2):**
-  - Use `this.$set(obj, key, val)` for adding new properties to objects
-  - Use `this.$set(arr, index, val)` or `.splice()` for array modifications
-- **TypeScript Types:** Explicit types for props, return values, and complex objects
-- **Props:** Always define `type`, `required`, and `default` where applicable
-- **Template Complexity:** Extract complex logic into computed properties, not in template
-
-### UI & i18n
-
-- **Styling:** Use Vuetify 2 utility classes (e.g., `ma-2`, `pa-0`, `d-flex`) whenever possible instead of custom CSS.
-- **Icons:** Import from `@mdi/js` (e.g., `mdiInformation`)
-- **i18n:** Localize all UI texts via `$t()`, no hardcoded strings
-- **Locales:** JSON files in `src/locales/` must have sorted keys (case-insensitive, enforced by ESLint/Prettier)
-
-## Code Review Guidelines
-
-### How to Review (for AI Agents)
-
-- Only comment when confidence is HIGH (>80%) that an issue exists
-- Be concise: one sentence per comment when possible
-- Focus on changed files only
-- Propose minimal, targeted fixes with line references
-
-### What to Check
-
-- Ensure adherence to code style guidelines
-- Verify TypeScript types and interfaces
-- New strings added to en.json (alphabetically sorted)
-- No raw `console.log` statements in production code. For intentional debug/logging output, define a **module-scoped**
-  `log()` helper that wraps `console.log` with a descriptive prefix (e.g., `[WebRTC camera-streamer]`), and use it
-  consistently within that file. See `WebrtcCameraStreamer.vue` for a reference implementation.
-- **Performance:** Use `@Debounce(ms)` for inputs triggering API calls, `throttle()` for resize handlers
-- **Cleanup in `beforeDestroy`:** Remove event listeners, clear timers, disconnect observers, dispose ECharts, close
-  WebSocket/WebRTC connections
-- **No Dead Code**: Remove unused variables, imports, and commented-out code blocks.
-- **Early Returns**: Use guard clauses to handle edge cases early and avoid deep nesting of `if/else` statements.
-- **Single Responsibility**: Functions and classes should do one thing and do it well. If a function exceeds 20-30
-  lines, consider refactoring.
-- **Magic Numbers:** Use named constants instead of raw numbers. The name should explain the meaning.
-
-  ```
-  // Bad
-  if (status === 3) { ... }
-
-  // Good
-  const STATUS_PRINTING = 3
-  if (status === STATUS_PRINTING) { ... }
-  ```
-
-## Contributing
-
-- Submit PRs against `develop` branch (not `master`)
-- PR titles follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `fix:`, `feat:`, `docs:`)
-- Sign off commits with DCO: `Signed-off-by: Name <email@example.com>`
-- Run `npm run format && npm run lint:fix` before committing
+| Topic                             | File                                                         |
+| --------------------------------- | ------------------------------------------------------------ |
+| Project structure & store modules | [agent_docs/ARCHITECTURE.md](agent_docs/ARCHITECTURE.md)     |
+| Vue Class Components & TypeScript | [agent_docs/VUE_TYPESCRIPT.md](agent_docs/VUE_TYPESCRIPT.md) |
+| Formatting, naming, patterns      | [agent_docs/CODE_STYLE.md](agent_docs/CODE_STYLE.md)         |
+| Vuetify, icons, i18n              | [agent_docs/UI_I18N.md](agent_docs/UI_I18N.md)               |
+| Code review checklist             | [agent_docs/CODE_REVIEW.md](agent_docs/CODE_REVIEW.md)       |
+| Git workflow & PRs                | [agent_docs/CONTRIBUTING.md](agent_docs/CONTRIBUTING.md)     |

--- a/agent_docs/ARCHITECTURE.md
+++ b/agent_docs/ARCHITECTURE.md
@@ -1,0 +1,61 @@
+# Architecture
+
+**Stack:** Vue 2.7, Vuetify 2, Vuex 3, TypeScript (strict), Vite
+
+## Project Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/components/` | Vue components by feature (dialogs/, panels/, inputs/, webcams/, console/, charts/) |
+| `src/components/mixins/` | Reusable Vue mixins |
+| `src/pages/` | Page components (Dashboard, Console, Files, Settings) |
+| `src/store/` | Vuex modules |
+| `src/plugins/` | Vue plugins and utilities |
+| `src/locales/` | Translation JSON files |
+| `src/types/` | TypeScript type definitions |
+
+## Vuex Store Modules
+
+### `src/store/socket/`
+WebSocket connection state
+
+### `src/store/server/`
+Moonraker API state with submodules:
+- `announcements/` - Server announcements
+- `history/` - Print history and statistics
+- `jobQueue/` - Print job queue
+- `power/` - Power device management
+- `sensor/` - Sensor data
+- `spoolman/` - Filament spool management
+- `timelapse/` - Timelapse recording
+- `updateManager/` - Software updates
+
+### `src/store/printer/`
+Printer state (temperatures, toolhead, extruders)
+
+### `src/store/gui/`
+UI state with submodules:
+- `console/` - Console settings
+- `gcodehistory/` - G-code command history
+- `heightmap/` - Bed mesh visualization
+- `macros/` - Macro management
+- `maintenance/` - Maintenance tracking
+- `miscellaneous/` - Misc UI settings
+- `navigation/` - Navigation state
+- `notifications/` - UI notifications
+- `presets/` - Temperature presets
+- `reminders/` - User reminders
+- `remoteprinters/` - Multi-printer config
+- `webcams/` - Webcam configuration
+
+### `src/store/files/`
+File browser state
+
+### `src/store/farm/`
+Multi-printer management
+
+### `src/store/editor/`
+Config file editor state
+
+### `src/store/gcodeviewer/`
+G-code viewer state

--- a/agent_docs/CODE_REVIEW.md
+++ b/agent_docs/CODE_REVIEW.md
@@ -1,0 +1,37 @@
+# Code Review
+
+## How to Review
+
+- Comment only when confidence >80% an issue exists
+- One sentence per comment when possible
+- Focus on changed files only
+- Propose minimal fixes with line references
+
+## Checklist
+
+### Code Quality ([CODE_STYLE.md](CODE_STYLE.md))
+
+- [ ] TypeScript types explicit and correct
+- [ ] No unused variables, imports, or dead code
+- [ ] Early returns used (no deep nesting)
+- [ ] Functions follow single responsibility
+- [ ] Magic numbers replaced with named constants
+
+### Vue Components ([VUE_TYPESCRIPT.md](VUE_TYPESCRIPT.md))
+
+- [ ] Uses Vue Class Component syntax
+- [ ] Class member order correct (@Prop → Data → Getters → Methods → @Watch → Lifecycle)
+- [ ] `beforeDestroy` cleans up all resources
+- [ ] Complex template logic extracted to computed properties
+
+### UI & i18n ([UI_I18N.md](UI_I18N.md))
+
+- [ ] All UI text uses `$t()`
+- [ ] New strings in `en.json` alphabetically sorted
+- [ ] Vuetify utility classes preferred over custom CSS
+
+### Performance
+
+- [ ] `@Debounce(ms)` on inputs triggering API calls
+- [ ] `throttle()` on resize handlers
+- [ ] No raw `console.log`

--- a/agent_docs/CODE_REVIEW.md
+++ b/agent_docs/CODE_REVIEW.md
@@ -20,7 +20,7 @@
 ### Vue Components ([VUE_TYPESCRIPT.md](VUE_TYPESCRIPT.md))
 
 - [ ] Uses Vue Class Component syntax
-- [ ] Class member order correct (@Prop → Data → Getters → Methods → @Watch → Lifecycle)
+- [ ] Class member order correct (`@Prop` → Data → Getters → `@Watch` → Lifecycle → Methods
 - [ ] `beforeDestroy` cleans up all resources
 - [ ] Complex template logic extracted to computed properties
 

--- a/agent_docs/CODE_STYLE.md
+++ b/agent_docs/CODE_STYLE.md
@@ -1,0 +1,74 @@
+# Code Style
+
+## Formatting
+
+Prettier enforces: 4-space indent, single quotes, no semicolons, 120 char width.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for commands.
+
+## Naming
+
+- **PascalCase** - Components, classes, types, interfaces
+- **camelCase** - Functions, variables, methods
+
+## Nullish Handling
+
+Use `??` for default values (checks null/undefined only):
+```typescript
+const value = input ?? 'default'
+```
+
+Use `||` only when checking all falsy values.
+
+## No Dead Code
+
+Remove unused variables, imports, and commented-out code immediately.
+
+## Comments
+
+Explain "why", not "what". Code should be self-documenting.
+
+## Early Returns
+
+Use guard clauses to avoid deep nesting:
+```typescript
+function process(item) {
+    if (!item) return
+    if (!item.isValid) return
+    // main logic here
+}
+```
+
+## Single Responsibility
+
+Functions should do one thing.
+Consider refactoring if exceeding 20-30 lines.
+
+## Magic Numbers
+
+Use named constants:
+```typescript
+const STATUS_PRINTING = 3
+if (status === STATUS_PRINTING) { ... }
+```
+
+## Performance
+
+Use `@Debounce(ms)` for inputs triggering API calls.
+Use `throttle()` for resize handlers.
+
+## Console Logging
+
+No raw `console.log` in production code.
+
+For debug output, define a class method with a descriptive prefix:
+```typescript
+log(msg: string, obj?: unknown): void {
+    const message = `[MyFeature] ${msg}`
+    if (obj) {
+        window.console.log(message, obj)
+        return
+    }
+    window.console.log(message)
+}
+```

--- a/agent_docs/CONTRIBUTING.md
+++ b/agent_docs/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+## Git Workflow
+
+Submit PRs against `develop` branch (not `master`).
+
+Sign off commits with DCO:
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+Format: `type(scope): message`
+
+Scope is optional but recommended for clarity (e.g., `fix(webcam): ...`, `feat(console): ...`).
+
+Types:
+- `feat` - New feature
+- `fix` - Bug fix
+- `docs` - Documentation
+- `refactor` - Code refactoring
+- `style` - Formatting changes
+- `test` - Adding tests
+- `chore` - Maintenance
+
+## Before Submitting
+
+```bash
+npm run format
+npm run lint:fix
+npm run test:unit
+```

--- a/agent_docs/UI_I18N.md
+++ b/agent_docs/UI_I18N.md
@@ -1,0 +1,33 @@
+# UI & Internationalization
+
+## Vuetify
+
+Use Vuetify 2 utility classes instead of custom CSS.
+
+Documentation: [Vuetify 2 Spacing](https://v2.vuetifyjs.com/en/styles/spacing/) | [Flex](https://v2.vuetifyjs.com/en/styles/flex/) | [Typography](https://v2.vuetifyjs.com/en/styles/text-and-typography/)
+
+## Icons
+
+Import icons from `@mdi/js`.
+Assign to class property and use in template.
+
+Icon search: [Material Design Icons](https://pictogrammers.com/library/mdi/)
+
+## Internationalization
+
+All UI text must use `$t()` for localization.
+No hardcoded user-facing strings.
+
+Documentation: [vue-i18n](https://kazupon.github.io/vue-i18n/)
+
+### Locale Files
+
+Location: `src/locales/`
+Format: JSON with alphabetically sorted keys (case-insensitive)
+
+Sorting is enforced by ESLint/Prettier.
+
+### Adding New Strings
+
+1. Add to `en.json` first
+2. Place in alphabetical order within the section

--- a/agent_docs/VUE_TYPESCRIPT.md
+++ b/agent_docs/VUE_TYPESCRIPT.md
@@ -1,0 +1,43 @@
+# Vue & TypeScript
+
+## Vue Class Components
+
+Use Vue Class Component with TypeScript decorators.
+Never use Vue 3 `<script setup>` or Options API.
+
+See canonical example: [examples/VueComponentExample.vue](examples/VueComponentExample.vue)
+
+### Class Member Order
+
+1. `@Prop` declarations
+2. Data fields (class properties)
+3. Getters (computed properties)
+4. Methods
+5. `@Watch` decorators
+6. Lifecycle hooks (mounted, beforeDestroy)
+
+### Documentation
+
+- [vue-class-component](https://class-component.vuejs.org/)
+- [vue-property-decorator](https://github.com/kaorun343/vue-property-decorator)
+
+## TypeScript
+
+Use explicit types for props, return values, and complex objects.
+Use `@/` alias for imports (e.g., `import { foo } from '@/store/types'`).
+
+Define `type`, `required`, and `default` for all props.
+
+## Template Best Practices
+
+Extract complex logic into computed properties.
+Keep templates declarative - no inline filtering or complex expressions.
+
+## Cleanup in beforeDestroy
+
+Always clean up resources:
+- Event listeners
+- Timers and intervals
+- Observers (ResizeObserver, MutationObserver)
+- ECharts instances
+- WebSocket/WebRTC connections

--- a/agent_docs/VUE_TYPESCRIPT.md
+++ b/agent_docs/VUE_TYPESCRIPT.md
@@ -12,9 +12,9 @@ See canonical example: [examples/VueComponentExample.vue](examples/VueComponentE
 1. `@Prop` declarations
 2. Data fields (class properties)
 3. Getters (computed properties)
-4. Methods
-5. `@Watch` decorators
-6. Lifecycle hooks (mounted, beforeDestroy)
+4. `@Watch` decorators
+5. Lifecycle hooks (mounted, beforeDestroy)
+6. Methods
 
 ### Documentation
 
@@ -36,6 +36,7 @@ Keep templates declarative - no inline filtering or complex expressions.
 ## Cleanup in beforeDestroy
 
 Always clean up resources:
+
 - Event listeners
 - Timers and intervals
 - Observers (ResizeObserver, MutationObserver)

--- a/agent_docs/examples/VueComponentExample.vue
+++ b/agent_docs/examples/VueComponentExample.vue
@@ -46,22 +46,13 @@ export default class VueComponentExample extends Mixins(BaseMixin) {
         return this.count > 0 && !this.isLoading
     }
 
-    // 4. Methods
-    handleClick(): void {
-        this.count++
-    }
-
-    onResize(): void {
-        // Handle resize
-    }
-
-    // 5. Watchers
+    // 4. Watchers
     @Watch('initialCount', { immediate: true })
     onInitialCountChanged(newVal: number): void {
         this.count = newVal
     }
 
-    // 6. Lifecycle hooks
+    // 5. Lifecycle hooks
     mounted(): void {
         window.addEventListener('resize', this.onResize)
     }
@@ -74,6 +65,15 @@ export default class VueComponentExample extends Mixins(BaseMixin) {
         // - WebSocket/WebRTC connections
         // - ECharts instances
         window.removeEventListener('resize', this.onResize)
+    }
+
+    // 6. Methods
+    handleClick(): void {
+        this.count++
+    }
+
+    onResize(): void {
+        // Handle resize
     }
 }
 </script>

--- a/agent_docs/examples/VueComponentExample.vue
+++ b/agent_docs/examples/VueComponentExample.vue
@@ -1,0 +1,79 @@
+<template>
+    <div>
+        <v-btn :disabled="isLoading" @click="handleClick">
+            <v-icon left>{{ mdiCheck }}</v-icon>
+            {{ $t('Common.Save') }}
+        </v-btn>
+    </div>
+</template>
+
+<script lang="ts">
+/**
+ * Canonical example of Vue Class Component structure.
+ * This file serves as a reference for AI agents - do not delete.
+ *
+ * Class member order:
+ * 1. @Prop declarations
+ * 2. Data fields (class properties)
+ * 3. Getters (computed properties)
+ * 4. Methods
+ * 5. @Watch decorators
+ * 6. Lifecycle hooks (mounted, beforeDestroy, etc.)
+ */
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import { mdiCheck } from '@mdi/js'
+
+@Component
+export default class VueComponentExample extends Mixins(BaseMixin) {
+    // Icons
+    mdiCheck = mdiCheck
+
+    // 1. Props
+    @Prop({ type: String, required: true }) readonly title!: string
+    @Prop({ type: Number, default: 0 }) readonly initialCount!: number
+
+    // 2. Data fields
+    isLoading = false
+    count = 0
+
+    // 3. Getters (computed properties)
+    get formattedTitle(): string {
+        return this.title.toUpperCase()
+    }
+
+    get isValid(): boolean {
+        return this.count > 0 && !this.isLoading
+    }
+
+    // 4. Methods
+    handleClick(): void {
+        this.count++
+    }
+
+    onResize(): void {
+        // Handle resize
+    }
+
+    // 5. Watchers
+    @Watch('initialCount', { immediate: true })
+    onInitialCountChanged(newVal: number): void {
+        this.count = newVal
+    }
+
+    // 6. Lifecycle hooks
+    mounted(): void {
+        window.addEventListener('resize', this.onResize)
+    }
+
+    beforeDestroy(): void {
+        // Always clean up:
+        // - Event listeners
+        // - Timers/intervals
+        // - Observers
+        // - WebSocket/WebRTC connections
+        // - ECharts instances
+        window.removeEventListener('resize', this.onResize)
+    }
+}
+</script>


### PR DESCRIPTION
## Description

This PR refactors `AGENTS.md` by splitting it into smaller, focused files in agent_docs/:

 - `ARCHITECTURE.md` - Project structure & store modules
 - `VUE_TYPESCRIPT.md` - Vue Class Components & TypeScript patterns
 - `CODE_STYLE.md` - Formatting, naming, general patterns
 - `UI_I18N.md` - Vuetify, icons, i18n
 - `CODE_REVIEW.md` - Review checklist
 - `CONTRIBUTING.md` - Git workflow & PRs

 Also adds a symlink (`.github/agent_docs`) so that `copilot-instructions.md` can resolve the relative
 links to the docs.

## Related Tickets & Documents

- https://www.aihero.dev/a-complete-guide-to-agents-md
- https://www.humanlayer.dev/blog/writing-a-good-claude-md

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
