### PR TITLE
fix(HappyHare): Fixes sync-feedback buffer state output in visualization and supports analog sensors

### DIFF
--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -9,16 +9,16 @@
         <use xlink:href="#sync-feedback-buffer-box" transform="translate(232, 212)" />
         <g v-if="syncFeedbackActive">
             <transition name="fade">
-                <g v-if="hasFilamentTensionSensor && hasFilamentCompressionSensor" key="neutral">
+                <g v-if="syncFeedbackState === 'neutral'" key="neutral">
                     <text x="298" y="240">Neutral</text>
                     <use xlink:href="#sync-feedback" transform="translate(296, 247.5) scale(1.0,-1.0) rotate(90)" />
                 </g>
-                <g v-else-if="hasFilamentTensionSensor" key="tension">
+                <g v-else-if="syncFeedbackState === 'tension'" key="tension">
                     <text x="298" y="240">Tension</text>
                     <use xlink:href="#sync-feedback" transform="translate(272, 199) scale(1.2)" />
                     <use xlink:href="#sync-feedback" transform="translate(272, 271) scale(1.2,-1.2)" />
                 </g>
-                <g v-else-if="hasFilamentCompressionSensor" key="compression">
+                <g v-else-if="syncFeedbackState === 'compressed'" key="compression">
                     <text x="298" y="240">Compression</text>
                     <use xlink:href="#sync-feedback" transform="translate(272, 235) scale(1.2)" />
                     <use xlink:href="#sync-feedback" transform="translate(272, 235) scale(1.2,-1.2)" />
@@ -47,6 +47,10 @@ export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, Mmu
 
     get syncFeedbackPistonPos(): number {
         return this.syncFeedbackBiasModelled * 12 + 234
+    }
+
+    get syncFeedbackState() {
+        return this.mmu?.sync_feedback_state ?? ''
     }
 }
 </script>


### PR DESCRIPTION
## Description
This PR fixes the incorrect display of sync-feedback buffer state on certain sensor types. Happy Hare supports dual-switch sensors, compression-only switch, tension-only switch as well as newer analog (proportional) sensors.  Previously the code looked at sensor switch state for these annotations. Now it uses the Happy Hare support status which allows for configuration on the zone for tension/compressed states.  It also now works correctly with analog/proportional sensors.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
The buffer rendering is unchanged except for the correct display of "Neutral", "Compressed", or "Tension" status under all conditions:
<img width="271" height="149" alt="sync_feedback_fixes_after" src="https://github.com/user-attachments/assets/0545c74b-3a7c-4825-99ed-5e86a585ecc5" />


## [optional] Are there any post-deployment tasks we need to perform?
n/a
