### PR TITLE
fix(HappyHare): Retains the correct font size for filament status messages

### DIFF
--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -209,6 +209,7 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
+import { capitalize } from '@/plugins/helpers'
 import MmuMixin, {
     ACTION_IDLE,
     ACTION_LOADING,

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -1,5 +1,5 @@
 <template>
-    <svg ref="filStatusSvg" viewBox="140 20 285 421" preserveAspectRatio="xMidYMid meet" class="svg-colors">
+    <svg ref="filStatusSvg" viewBox="140 0 285 441" preserveAspectRatio="xMidYMid meet" class="svg-colors">
         <defs>
             <g
                 id="sync-feedback"
@@ -73,6 +73,10 @@
                     vector-effect="non-scaling-stroke" />
             </g>
         </defs>
+
+        <text x="282" y="18" font-size="16px" text-anchor="middle">
+            {{ statusText }}
+        </text>
 
         <rect x="150" y="30" width="265" height="130" class="zone-background" rx="10" ry="10" />
         <rect x="150" y="333" width="265" height="66" class="zone-background" rx="10" ry="10" />
@@ -206,6 +210,9 @@
 import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import MmuMixin, {
+    ACTION_IDLE,
+    ACTION_LOADING,
+    ACTION_UNLOADING,
     ACTION_CUTTING_FILAMENT,
     ACTION_CUTTING_TIP,
     ACTION_FORMING_TIP,
@@ -429,6 +436,33 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
 
     get syncFeedbackPistonText() {
         return (this.mmu?.sync_feedback_bias_modelled ?? 0.0).toFixed(2)
+    }
+
+    get statusText() {
+        if (['complete', 'error', 'cancelled', 'started'].includes(this.mmuPrintState)) {
+            return capitalize(this.mmuPrintState)
+        }
+
+        if ([ACTION_LOADING, ACTION_UNLOADING].includes(this.mmuAction)) {
+            return `${this.mmuAction}: ${this.filamentPosition}mm`
+        }
+
+        if (this.mmuAction !== ACTION_IDLE) return this.mmuAction
+
+        if (this.mmuPrintState === 'printing') {
+            let str = `Printing (${this.numToolchanges}`
+            if (this.totalToolchanges > 0) str += `/${this.totalToolchanges}`
+            str += ' swaps)'
+            return str
+        }
+
+        const filament = this.mmu?.filament ?? 'Unknown'
+
+        return filament !== 'Unloaded' ? `Filament: ${this.filamentPosition}mm` : 'Filament: Unloaded'
+    }
+
+    get filamentPosition() {
+        return (this.mmu?.filament_position ?? 0).toFixed(1)
     }
 }
 </script>

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -434,8 +434,20 @@ export default class MmuFilamentStatus extends Mixins(BaseMixin, MmuMixin) {
         return this.mmuGrip === 'Gripped' || this.mmuServo === 'Down'
     }
 
+    get slicerToolMap() {
+        return this.mmu?.slicer_tool_map ?? undefined
+    }
+
     get syncFeedbackPistonText() {
         return (this.mmu?.sync_feedback_bias_modelled ?? 0.0).toFixed(2)
+    }
+
+    get totalToolchanges() {
+        return this.slicerToolMap?.total_toolchanges ?? 0
+    }
+
+    get numToolchanges() {
+        return this.mmu?.num_toolchanges ?? 0
     }
 
     get statusText() {

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -218,18 +218,6 @@ export default class MmuPanel extends Mixins(BaseMixin, MmuMixin) {
         return this.$store.state.gui.view.mmu.showDetails ?? true
     }
 
-    get slicerToolMap() {
-        return this.mmu?.slicer_tool_map ?? undefined
-    }
-
-    get totalToolchanges() {
-        return this.slicerToolMap?.total_toolchanges ?? 0
-    }
-
-    get numToolchanges() {
-        return this.mmu?.num_toolchanges ?? 0
-    }
-
     get toolchangeText() {
         if (this.nextTool === TOOL_GATE_UNKNOWN) return ''
 

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -134,11 +134,7 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
-import MmuMixin, {
-    TOOL_GATE_BYPASS,
-    TOOL_GATE_UNKNOWN,
-} from '@/components/mixins/mmu'
-import { capitalize } from '@/plugins/helpers'
+import MmuMixin, { TOOL_GATE_BYPASS, TOOL_GATE_UNKNOWN } from '@/components/mixins/mmu'
 import { mdiMulticast, mdiDotsVertical, mdiCheckAll, mdiNoteText, mdiInformationOutline, mdiRefresh } from '@mdi/js'
 import Panel from '@/components/ui/Panel.vue'
 import MmuPanelSettings from '@/components/panels/Mmu/MmuPanelSettings.vue'

--- a/src/components/panels/MmuPanel.vue
+++ b/src/components/panels/MmuPanel.vue
@@ -82,8 +82,7 @@
             </v-row>
             <v-row>
                 <v-col :cols="col1Size">
-                    <div class="text--disabled body-2">{{ toolchangeText }}</div>
-                    <div class="text-center body-1">{{ statusText }}</div>
+                    <div class="text--disabled body-1">{{ toolchangeText }}</div>
                     <mmu-filament-status />
                     <div v-if="showClogDetection" class="text-center">
                         <mmu-clog-meter v-if="hasMmuEncoder" width="40%" />
@@ -136,9 +135,6 @@
 import { Component, Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import MmuMixin, {
-    ACTION_IDLE,
-    ACTION_LOADING,
-    ACTION_UNLOADING,
     TOOL_GATE_BYPASS,
     TOOL_GATE_UNKNOWN,
 } from '@/components/mixins/mmu'
@@ -258,35 +254,8 @@ export default class MmuPanel extends Mixins(BaseMixin, MmuMixin) {
         return this.mmu?.next_tool ?? TOOL_GATE_UNKNOWN
     }
 
-    get statusText() {
-        if (['complete', 'error', 'cancelled', 'started'].includes(this.mmuPrintState)) {
-            return capitalize(this.mmuPrintState)
-        }
-
-        if ([ACTION_LOADING, ACTION_UNLOADING].includes(this.mmuAction)) {
-            return `${this.mmuAction}: ${this.filamentPosition}mm`
-        }
-
-        if (this.mmuAction !== ACTION_IDLE) return this.mmuAction
-
-        if (this.mmuPrintState === 'printing') {
-            let str = `Printing (${this.numToolchanges}`
-            if (this.totalToolchanges > 0) str += `/${this.totalToolchanges}`
-            str += ' swaps)'
-            return str
-        }
-
-        const filament = this.mmu?.filament ?? 'Unknown'
-
-        return filament !== 'Unloaded' ? `Filament: ${this.filamentPosition}mm` : 'Filament: Unloaded'
-    }
-
     get reasonForPause() {
         return this.mmu?.reason_for_pause ?? null
-    }
-
-    get filamentPosition() {
-        return (this.mmu?.filament_position ?? 0).toFixed(1)
     }
 
     get fileForTtgMap() {


### PR DESCRIPTION
## Description
This PR moves the display of the "filament status message" which gives details of current movement from a vue text field and puts it in the filament status SVG.  This ensures the font remains proportional to the rest of the status information. Previously on very narrow or wide displays, text would wrap or be of the incorrect size.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
Example mismatch prior:
<img width="394" height="131" alt="filament_status_message_before copy" src="https://github.com/user-attachments/assets/1373dccd-ab19-4d7b-acff-8c5378ce7e02" />

Fixed as part of filament status component:
<img width="341" height="161" alt="filament_status_message_after" src="https://github.com/user-attachments/assets/311f4cbb-0d0c-4812-949b-8794e523fd8f" />


## [optional] Are there any post-deployment tasks we need to perform?
n/a