### PR TITLE
feat(HappyHare): Added to gate context menu for complete change-tool operation

### DIFF
--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -52,13 +52,14 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import MmuMixin, { MmuMachineUnit, TOOL_GATE_BYPASS } from '@/components/mixins/mmu'
-import { mdiSwapHorizontal, mdiDownloadOutline, mdiEject } from '@mdi/js'
+import { mdiSwapHorizontal, mdiDownloadOutline, mdiEject, mdiArrowDecision } from '@mdi/js'
 
 @Component
 export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     mdiSwapHorizontal = mdiSwapHorizontal
     mdiDownloadOutline = mdiDownloadOutline
     mdiEject = mdiEject
+    mdiArrowDecision = mdiArrowDecision
 
     @Prop({ required: true }) readonly gateIndex!: number
     @Prop({ required: true }) readonly mmuMachineUnit!: MmuMachineUnit
@@ -100,6 +101,11 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
             { icon: this.mdiSwapHorizontal, command: 'MMU_SELECT', label: this.$t('Panels.MmuPanel.ButtonSelect') },
             { icon: this.mdiDownloadOutline, command: 'MMU_PRELOAD', label: this.$t('Panels.MmuPanel.ButtonPreload') },
             { icon: this.mdiEject, command: 'MMU_EJECT', label: this.$t('Panels.MmuPanel.ButtonEject') },
+            {
+                icon: this.mdiArrowDecision,
+                command: 'MMU_CHANGE_TOOL',
+                label: this.$t('Panels.MmuPanel.ButtonChangeTool'),
+            },
         ]
     }
 

--- a/src/components/panels/Mmu/MmuUnitGate.vue
+++ b/src/components/panels/Mmu/MmuUnitGate.vue
@@ -52,14 +52,14 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import MmuMixin, { MmuMachineUnit, TOOL_GATE_BYPASS } from '@/components/mixins/mmu'
-import { mdiSwapHorizontal, mdiDownloadOutline, mdiEject, mdiArrowDecision } from '@mdi/js'
+import { mdiSwapHorizontal, mdiDownloadOutline, mdiEject, mdiAxisArrow } from '@mdi/js'
 
 @Component
 export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
     mdiSwapHorizontal = mdiSwapHorizontal
     mdiDownloadOutline = mdiDownloadOutline
     mdiEject = mdiEject
-    mdiArrowDecision = mdiArrowDecision
+    mdiAxisArrow = mdiAxisArrow
 
     @Prop({ required: true }) readonly gateIndex!: number
     @Prop({ required: true }) readonly mmuMachineUnit!: MmuMachineUnit
@@ -102,7 +102,7 @@ export default class MmuUnitGate extends Mixins(BaseMixin, MmuMixin) {
             { icon: this.mdiDownloadOutline, command: 'MMU_PRELOAD', label: this.$t('Panels.MmuPanel.ButtonPreload') },
             { icon: this.mdiEject, command: 'MMU_EJECT', label: this.$t('Panels.MmuPanel.ButtonEject') },
             {
-                icon: this.mdiArrowDecision,
+                icon: this.mdiAxisArrow,
                 command: 'MMU_CHANGE_TOOL',
                 label: this.$t('Panels.MmuPanel.ButtonChangeTool'),
             },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -777,6 +777,7 @@
         },
         "MmuPanel": {
             "Active": "Active",
+            "ButtonChangeTool": "Change Tool",
             "ButtonCheckAllGates": "Check All Gates",
             "ButtonCheckGate": "Check Gate",
             "ButtonEject": "Eject",


### PR DESCRIPTION
## Description
This PR simply adds an additional action button to the per-gate pop-up menu to request a complete toolchange.  This is for convenience and potentially saves the user time with separate UNLOAD / SELECT / LOAD operations.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
Simple adds the "Change Tool" menu item:
<img width="344" height="282" alt="changetool_menu_after" src="https://github.com/user-attachments/assets/4c3c1252-d4f5-4ca3-9568-85c7a07fefcf" />

## [optional] Are there any post-deployment tasks we need to perform?
n/a
