### PR TITLE
feat(HappyHare): Support for multi-gate espooler display (HH v3.2.4)

### DIFF
--- a/src/components/mixins/mmu.ts
+++ b/src/components/mixins/mmu.ts
@@ -3,6 +3,8 @@ import { W3C_COLORS } from '@/plugins/w3c'
 import { Mixins } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 
+export type MmuEspoolerState = 'rewind' | 'assist' | 'off'
+
 export interface Mmu {
     enabled: boolean
     num_gates: number
@@ -93,7 +95,7 @@ export interface Mmu {
     extruder_filament_remaining: number
     spoolman_support: 'off' | 'readonly' | 'push' | 'pull'
     bowden_progress: number
-    espooler_active: 'rewind' | 'assist' | 'off'
+    espooler_active: MmuEspoolerState
     sensors: {
         mmu_pre_gate?: boolean
         mmu_gear?: boolean
@@ -116,6 +118,7 @@ export interface Mmu {
         headroom: number
         min_headroom: number
     }
+    espooler?: MmuEspoolerState[]
 }
 
 export interface MmuMachine {
@@ -315,6 +318,10 @@ export default class MmuMixin extends Mixins(BaseMixin) {
 
     get mmuGrip() {
         return this.mmu?.grip ?? 'Unknown'
+    }
+
+    get mmuEspoolers() {
+        return this.mmu?.espooler
     }
 
     get configGateHomingEndstop(): string {

--- a/src/components/panels/Mmu/MmuUnitGateSpool.vue
+++ b/src/components/panels/Mmu/MmuUnitGateSpool.vue
@@ -205,20 +205,14 @@ export default class MmuUnitGateSpool extends Mixins(BaseMixin, MmuMixin) {
     }
 
     get isEspoolerRewind() {
-        const espoolers = this.mmu?.espooler
-        if (espoolers) {
-            return espoolers[this.gateIndex] === 'rewind'
-        }
+        if (this.mmuEspoolers) return this.mmuEspoolers[this.gateIndex] === 'rewind'
 
         // Legacy Happy Hare (selected gate only)
         return this.gateIndex === this.mmu?.gate && this.mmu?.espooler_active === 'rewind'
     }
 
     get isEspoolerAssist() {
-        const espoolers = this.mmu?.espooler
-        if (espoolers) {
-            return espoolers[this.gateIndex] === 'assist'
-        }
+        if (this.mmuEspoolers) return this.mmuEspoolers[this.gateIndex] === 'assist'
 
         // Legacy Happy Hare (selected gate only)
         return this.gateIndex === this.mmu?.gate && this.mmu?.espooler_active === 'assist'

--- a/src/components/panels/Mmu/MmuUnitGateSpool.vue
+++ b/src/components/panels/Mmu/MmuUnitGateSpool.vue
@@ -22,7 +22,7 @@
                     <path
                         id="espool"
                         d="M 89.561 35.5 L 60.333 15.734 c -0.308 -0.208 -0.704 -0.229 -1.029 -0.055 c -0.327 0.173 -0.531 0.513 -0.531 0.883 v 7.987 c -12.038 0.262 -26.306 5.201 -37.501 13.023 C 7.554 47.155 0 59.894 0 73.438 c 0 0.471 0.329 0.878 0.79 0.978 C 0.86 74.432 0.931 74.438 1 74.438 c 0.386 0 0.747 -0.225 0.911 -0.588 c 7.823 -17.312 26.952 -26.183 56.861 -26.376 v 8.62 c 0 0.37 0.204 0.71 0.531 0.883 c 0.325 0.173 0.722 0.153 1.029 -0.055 l 29.228 -19.766 C 89.835 36.971 90 36.661 90 36.329 S 89.835 35.686 89.561 35.5 z"
-                        stroke-width="2"
+                        stroke-width="3"
                         stroke="#CCCCCC"
                         fill="#808080"
                         opacity="0.7" />
@@ -95,7 +95,7 @@
                     <use
                         v-if="isEspoolerAssist"
                         href="#espool"
-                        transform="translate(225,500) rotate(270) scale(2,-2)" />
+                        transform="translate(225,480) rotate(270) scale(2,-2)" />
                 </g>
             </svg>
         </template>
@@ -205,15 +205,23 @@ export default class MmuUnitGateSpool extends Mixins(BaseMixin, MmuMixin) {
     }
 
     get isEspoolerRewind() {
-        if (this.gateIndex !== this.mmu?.gate) return false
+        const espoolers = this.mmu?.espooler
+        if (espoolers) {
+            return espoolers[this.gateIndex] === 'rewind'
+        }
 
-        return this.mmu?.espooler_active === 'rewind'
+        // Legacy Happy Hare v3.4.2 (selected gate only)
+        return this.gateIndex === this.mmu?.gate && this.mmu?.espooler_active === 'rewind'
     }
 
     get isEspoolerAssist() {
-        if (this.gateIndex !== this.mmu?.gate) return false
+        const espoolers = this.mmu?.espooler
+        if (espoolers) {
+            return espoolers[this.gateIndex] === 'assist'
+        }
 
-        return this.mmu?.espooler_active === 'assist'
+        // Legacy Happy Hare v3.4.2 (selected gate only)
+        return this.gateIndex === this.mmu?.gate && this.mmu?.espooler_active === 'assist'
     }
 
     get spoolWidth() {

--- a/src/components/panels/Mmu/MmuUnitGateSpool.vue
+++ b/src/components/panels/Mmu/MmuUnitGateSpool.vue
@@ -210,7 +210,7 @@ export default class MmuUnitGateSpool extends Mixins(BaseMixin, MmuMixin) {
             return espoolers[this.gateIndex] === 'rewind'
         }
 
-        // Legacy Happy Hare v3.4.2 (selected gate only)
+        // Legacy Happy Hare (selected gate only)
         return this.gateIndex === this.mmu?.gate && this.mmu?.espooler_active === 'rewind'
     }
 
@@ -220,7 +220,7 @@ export default class MmuUnitGateSpool extends Mixins(BaseMixin, MmuMixin) {
             return espoolers[this.gateIndex] === 'assist'
         }
 
-        // Legacy Happy Hare v3.4.2 (selected gate only)
+        // Legacy Happy Hare (selected gate only)
         return this.gateIndex === this.mmu?.gate && this.mmu?.espooler_active === 'assist'
     }
 


### PR DESCRIPTION
## Description
Previously an arrow representing espooler assist or rewind operation was only rendered on active gate.  With Happy Hare v3.2.4 then are features that allow other gate espoolers to activate independently.   This PR uses this additional information (if new printer variable is available) to extend the visual feedback to any/all gates. The original functionality is a fallback for older versions of Happy Hare.

## Related Tickets & Documents
n/a

## Mobile & Desktop Screenshots/Recordings
This screenshot shows the espooler assist/rewind arrows simultaneous on different gates.
<img width="335" height="218" alt="multi_gate_assist_after" src="https://github.com/user-attachments/assets/ba79d0d7-5028-4ea9-85c5-a30c1b322049" />

## [optional] Are there any post-deployment tasks we need to perform?
n/a
