### PR TITLE
style: fix formatting in agent_docs

### DIFF
--- a/agent_docs/ARCHITECTURE.md
+++ b/agent_docs/ARCHITECTURE.md
@@ -4,23 +4,26 @@
 
 ## Project Structure
 
-| Directory | Purpose |
-|-----------|---------|
-| `src/components/` | Vue components by feature (dialogs/, panels/, inputs/, webcams/, console/, charts/) |
-| `src/components/mixins/` | Reusable Vue mixins |
-| `src/pages/` | Page components (Dashboard, Console, Files, Settings) |
-| `src/store/` | Vuex modules |
-| `src/plugins/` | Vue plugins and utilities |
-| `src/locales/` | Translation JSON files |
-| `src/types/` | TypeScript type definitions |
+| Directory                | Purpose                                                                             |
+| ------------------------ | ----------------------------------------------------------------------------------- |
+| `src/components/`        | Vue components by feature (dialogs/, panels/, inputs/, webcams/, console/, charts/) |
+| `src/components/mixins/` | Reusable Vue mixins                                                                 |
+| `src/pages/`             | Page components (Dashboard, Console, Files, Settings)                               |
+| `src/store/`             | Vuex modules                                                                        |
+| `src/plugins/`           | Vue plugins and utilities                                                           |
+| `src/locales/`           | Translation JSON files                                                              |
+| `src/types/`             | TypeScript type definitions                                                         |
 
 ## Vuex Store Modules
 
 ### `src/store/socket/`
+
 WebSocket connection state
 
 ### `src/store/server/`
+
 Moonraker API state with submodules:
+
 - `announcements/` - Server announcements
 - `history/` - Print history and statistics
 - `jobQueue/` - Print job queue
@@ -31,10 +34,13 @@ Moonraker API state with submodules:
 - `updateManager/` - Software updates
 
 ### `src/store/printer/`
+
 Printer state (temperatures, toolhead, extruders)
 
 ### `src/store/gui/`
+
 UI state with submodules:
+
 - `console/` - Console settings
 - `gcodehistory/` - G-code command history
 - `heightmap/` - Bed mesh visualization
@@ -49,13 +55,17 @@ UI state with submodules:
 - `webcams/` - Webcam configuration
 
 ### `src/store/files/`
+
 File browser state
 
 ### `src/store/farm/`
+
 Multi-printer management
 
 ### `src/store/editor/`
+
 Config file editor state
 
 ### `src/store/gcodeviewer/`
+
 G-code viewer state

--- a/agent_docs/CODE_STYLE.md
+++ b/agent_docs/CODE_STYLE.md
@@ -14,6 +14,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for commands.
 ## Nullish Handling
 
 Use `??` for default values (checks null/undefined only):
+
 ```typescript
 const value = input ?? 'default'
 ```
@@ -31,11 +32,12 @@ Explain "why", not "what". Code should be self-documenting.
 ## Early Returns
 
 Use guard clauses to avoid deep nesting:
+
 ```typescript
 function process(item) {
-    if (!item) return
-    if (!item.isValid) return
-    // main logic here
+  if (!item) return
+  if (!item.isValid) return
+  // main logic here
 }
 ```
 
@@ -47,6 +49,7 @@ Consider refactoring if exceeding 20-30 lines.
 ## Magic Numbers
 
 Use named constants:
+
 ```typescript
 const STATUS_PRINTING = 3
 if (status === STATUS_PRINTING) { ... }
@@ -62,6 +65,7 @@ Use `throttle()` for resize handlers.
 No raw `console.log` in production code.
 
 For debug output, define a class method with a descriptive prefix:
+
 ```typescript
 log(msg: string, obj?: unknown): void {
     const message = `[MyFeature] ${msg}`

--- a/agent_docs/CONTRIBUTING.md
+++ b/agent_docs/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 Submit PRs against `develop` branch (not `master`).
 
 Sign off commits with DCO:
+
 ```
 Signed-off-by: Your Name <your.email@example.com>
 ```
@@ -18,6 +19,7 @@ Format: `type(scope): message`
 Scope is optional but recommended for clarity (e.g., `fix(webcam): ...`, `feat(console): ...`).
 
 Types:
+
 - `feat` - New feature
 - `fix` - Bug fix
 - `docs` - Documentation


### PR DESCRIPTION
## Description

This PR just fix some format issues in the agent_docs/* files. I just run `npm run format` commit and push.

## Related Tickets & Documents

- I saw some issues in these files here: https://github.com/mainsail-crew/mainsail/pull/2436/checks?check_run_id=63295994199

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
