### PR TITLE
ci: fix linter workflow to run ESLint and Prettier separately

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,8 +8,6 @@ jobs:
   code-style:
     name: Code style check
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -22,11 +20,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run linters
-        uses: wearerequired/lint-action@v2
-        with:
-          eslint: true
-          prettier: true
+      - name: Run ESLint
+        run: npx eslint --max-warnings 0 .
+
+      - name: Run Prettier
+        run: npx prettier --check .
 
   check-translations:
     name: Check translations


### PR DESCRIPTION
## Description

This PR fix the code style check. The old one would need pull_request_target, which would be a security issue. This method would just fail the check and will not create comments in the code diff.

## Related Tickets & Documents

- here you can see the error in the workflow: https://github.com/mainsail-crew/mainsail/actions/runs/22586472281/job/65432678406?pr=2452#step:5:80

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
