### PR TITLE
feat: native per-tool spool assignment via Moonraker API

### DIFF
--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -230,8 +230,13 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
         if (this.tool) {
             if (this.hasToolSpools) {
                 // Parse tool number from string like "T0"
-                const match = this.tool.match(/T(\d+)/i)
-                const toolNum = match ? parseInt(match[1]) : 0
+                const match = this.tool.match(/^T(\d+)$/i)
+                if (!match) {
+                    this.setMacroVariable(spool)
+                    this.close()
+                    return
+                }
+                const toolNum = Number.parseInt(match[1], 10)
                 this.$store.dispatch('server/spoolman/setToolSpool', {
                     tool: toolNum,
                     spool_id: spool.id,

--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -92,6 +92,7 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
     mdiRefresh = mdiRefresh
 
     @VModel({ type: Boolean }) showDialog!: boolean
+    @Prop({ required: false, default: null }) declare readonly toolIndex?: number | null
     @Prop({ required: false, default: null }) declare readonly tool?: string
     @Prop({ required: false, default: null }) declare readonly afcLane?: string
     @Prop({ required: false, default: true }) declare readonly setActiveSpool?: boolean
@@ -140,6 +141,11 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
                 value: 'remaining_weight',
             },
         ]
+    }
+
+    get hasToolSpools(): boolean {
+        const toolSpools = this.$store.state.server.spoolman.tool_spools ?? {}
+        return Object.keys(toolSpools).length > 0
     }
 
     get existsSaveVariables() {
@@ -204,9 +210,35 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
             return
         }
 
-        // if tool is set, execute setMacroVariable and close, because it's not an active printing spool change
+        // If toolIndex is set, use Moonraker API to set per-tool spool
+        if (this.toolIndex !== null && this.toolIndex !== undefined) {
+            if (this.hasToolSpools) {
+                // Use Moonraker per-tool API
+                this.$store.dispatch('server/spoolman/setToolSpool', {
+                    tool: this.toolIndex,
+                    spool_id: spool.id,
+                })
+            } else {
+                // Legacy fallback: use gcode_macro variable
+                this.setMacroVariable(spool)
+            }
+            this.close()
+            return
+        }
+
+        // Legacy tool prop (string-based, from old gcode_macro path)
         if (this.tool) {
-            this.setMacroVariable(spool)
+            if (this.hasToolSpools) {
+                // Parse tool number from string like "T0"
+                const match = this.tool.match(/T(\d+)/i)
+                const toolNum = match ? parseInt(match[1]) : 0
+                this.$store.dispatch('server/spoolman/setToolSpool', {
+                    tool: toolNum,
+                    spool_id: spool.id,
+                })
+            } else {
+                this.setMacroVariable(spool)
+            }
             this.close()
             return
         }
@@ -217,8 +249,11 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
     }
 
     setMacroVariable(spool: ServerSpoolmanStateSpool) {
+        const macroName = this.tool ?? (this.toolIndex !== null ? `T${this.toolIndex}` : null)
+        if (!macroName) return
+
         // Set spool_id for tool
-        this.sendGcode(`SET_GCODE_VARIABLE MACRO=${this.tool} VARIABLE=spool_id VALUE=${spool.id}`)
+        this.sendGcode(`SET_GCODE_VARIABLE MACRO=${macroName} VARIABLE=spool_id VALUE=${spool.id}`)
 
         // Close dialog if save_variables is not enabled
         if (!this.existsSaveVariables) {
@@ -227,7 +262,7 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
         }
 
         // Set spool_id to save_variable
-        this.sendGcode(`SAVE_VARIABLE VARIABLE=${this.tool?.toLowerCase()}__spool_id VALUE=${spool.id}`)
+        this.sendGcode(`SAVE_VARIABLE VARIABLE=${macroName.toLowerCase()}__spool_id VALUE=${spool.id}`)
     }
 
     sendGcode(gcode: string) {

--- a/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
+++ b/src/components/dialogs/SpoolmanChangeSpoolDialog.vue
@@ -249,7 +249,7 @@ export default class SpoolmanChangeSpoolDialog extends Mixins(BaseMixin) {
     }
 
     setMacroVariable(spool: ServerSpoolmanStateSpool) {
-        const macroName = this.tool ?? (this.toolIndex !== null ? `T${this.toolIndex}` : null)
+        const macroName = this.tool ?? (this.toolIndex != null ? `T${this.toolIndex}` : null)
         if (!macroName) return
 
         // Set spool_id for tool

--- a/src/components/dialogs/StartPrintDialogSpoolman.vue
+++ b/src/components/dialogs/StartPrintDialogSpoolman.vue
@@ -1,19 +1,29 @@
 <template>
     <v-card-text class="py-3 px-2 bt-1">
-        <spoolman-panel-active-spool
-            v-if="activeSpoolId !== null"
-            :small="true"
-            class="my-0"
-            @change-spool="showChangeSpoolDialog = true" />
-        <v-alert v-for="alert in alerts" :key="alert.text" text :color="alert.color" class="mx-3">
-            {{ alert.text }}
-        </v-alert>
-        <div class="text-center">
-            <v-btn color="primary" small class="mx-auto" @click="showChangeSpoolDialog = true">
-                {{ buttonText }}
-            </v-btn>
-        </div>
-        <spoolman-change-spool-dialog v-model="showChangeSpoolDialog" />
+        <template v-if="isMultiTool">
+            <start-print-dialog-spoolman-tool
+                v-for="(tool, index) in toolIndices"
+                :key="tool"
+                :file="file"
+                :tool-index="tool"
+                :border-top="index > 0" />
+        </template>
+        <template v-else>
+            <spoolman-panel-active-spool
+                v-if="activeSpoolId !== null"
+                :small="true"
+                class="my-0"
+                @change-spool="showChangeSpoolDialog = true" />
+            <v-alert v-for="alert in alerts" :key="alert.text" text :color="alert.color" class="mx-3">
+                {{ alert.text }}
+            </v-alert>
+            <div class="text-center">
+                <v-btn color="primary" small class="mx-auto" @click="showChangeSpoolDialog = true">
+                    {{ buttonText }}
+                </v-btn>
+            </div>
+            <spoolman-change-spool-dialog v-model="showChangeSpoolDialog" />
+        </template>
     </v-card-text>
 </template>
 
@@ -21,16 +31,40 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import SpoolmanPanelActiveSpool from '@/components/panels/Spoolman/SpoolmanPanelActiveSpool.vue'
+import StartPrintDialogSpoolmanTool from '@/components/dialogs/StartPrintDialogSpoolmanTool.vue'
+import SpoolmanChangeSpoolDialog from '@/components/dialogs/SpoolmanChangeSpoolDialog.vue'
 import { FileStateGcodefile } from '@/store/files/types'
 import { convertStringToArray } from '@/plugins/helpers'
 
 @Component({
-    components: { SpoolmanPanelActiveSpool },
+    components: { SpoolmanPanelActiveSpool, StartPrintDialogSpoolmanTool, SpoolmanChangeSpoolDialog },
 })
 export default class StartPrintDialogSpoolman extends Mixins(BaseMixin) {
     @Prop({ required: true }) readonly file!: FileStateGcodefile
 
     showChangeSpoolDialog = false
+
+    get toolSpools(): Record<number, number | null> {
+        return this.$store.state.server.spoolman?.tool_spools ?? {}
+    }
+
+    get toolIndices(): number[] {
+        return Object.keys(this.toolSpools).map((k) => parseInt(k)).sort((a, b) => a - b)
+    }
+
+    get isMultiTool(): boolean {
+        // Multi-tool if we have more than one tool in the map,
+        // or if the file references multiple filaments
+        if (this.toolIndices.length > 1) return true
+
+        const weights = this.file.filament_weights ?? []
+        if (weights.length > 1) return true
+
+        const types = convertStringToArray(this.file.filament_type ?? '')
+        if (types.length > 1) return true
+
+        return false
+    }
 
     get activeSpoolId() {
         let spoolId = this.$store.state.server.spoolman?.active_spool_id ?? null
@@ -41,14 +75,6 @@ export default class StartPrintDialogSpoolman extends Mixins(BaseMixin) {
 
     get activeSpool() {
         return this.$store.state.server.spoolman?.active_spool ?? null
-    }
-
-    get classSecondDivider() {
-        const classes = ['mt-4']
-
-        classes.push(this.moonrakerComponents.includes('timelapse') ? 'mb-2' : 'mb-0')
-
-        return classes
     }
 
     get buttonText() {

--- a/src/components/dialogs/StartPrintDialogSpoolman.vue
+++ b/src/components/dialogs/StartPrintDialogSpoolman.vue
@@ -49,21 +49,27 @@ export default class StartPrintDialogSpoolman extends Mixins(BaseMixin) {
     }
 
     get toolIndices(): number[] {
-        return Object.keys(this.toolSpools).map((k) => parseInt(k)).sort((a, b) => a - b)
+        // Build a canonical tool list from all available sources
+        const indices = new Set<number>()
+
+        // From Moonraker tool_spool_map
+        for (const k of Object.keys(this.toolSpools)) {
+            const n = Number.parseInt(k, 10)
+            if (!Number.isNaN(n)) indices.add(n)
+        }
+
+        // From file metadata (filament_weights array length implies tool count)
+        const weights = this.file.filament_weights ?? []
+        for (let i = 0; i < weights.length; i++) indices.add(i)
+
+        const types = convertStringToArray(this.file.filament_type ?? '')
+        for (let i = 0; i < types.length; i++) indices.add(i)
+
+        return Array.from(indices).sort((a, b) => a - b)
     }
 
     get isMultiTool(): boolean {
-        // Multi-tool if we have more than one tool in the map,
-        // or if the file references multiple filaments
-        if (this.toolIndices.length > 1) return true
-
-        const weights = this.file.filament_weights ?? []
-        if (weights.length > 1) return true
-
-        const types = convertStringToArray(this.file.filament_type ?? '')
-        if (types.length > 1) return true
-
-        return false
+        return this.toolIndices.length > 1
     }
 
     get activeSpoolId() {

--- a/src/components/dialogs/StartPrintDialogSpoolmanTool.vue
+++ b/src/components/dialogs/StartPrintDialogSpoolmanTool.vue
@@ -1,0 +1,122 @@
+<template>
+    <v-row :class="{ 'bt-1': borderTop }" class="px-6 py-2">
+        <v-col class="d-flex align-center shrink pr-0">
+            <v-tooltip v-if="warnings.length" top>
+                <template #activator="{ on, attrs }">
+                    <v-icon color="warning" v-bind="attrs" v-on="on">{{ mdiAlert }}</v-icon>
+                </template>
+                <span>{{ warnings.join('\n') }}</span>
+            </v-tooltip>
+            <v-icon v-else color="success">{{ mdiCheckCircle }}</v-icon>
+        </v-col>
+        <v-col class="d-flex align-center">
+            <span class="mr-3 text-subtitle-1 font-weight-bold">{{ toolName }}</span>
+            <span v-if="fileFilamentType" class="text-caption text--secondary">{{ fileFilamentType }}</span>
+        </v-col>
+        <v-col class="d-flex align-center justify-end">
+            <span v-if="spoolDetail" class="mr-2">
+                <span
+                    class="_extruderColorState mr-1"
+                    :style="{ 'background-color': '#' + (spoolDetail.filament?.color_hex ?? '000000') }" />
+                {{ spoolDetail.filament?.name ?? '--' }}
+                ({{ Math.round(spoolDetail.remaining_weight ?? 0) }}g)
+            </span>
+            <span v-else class="text--disabled mr-2">{{ $t('Panels.SpoolmanPanel.NoSpool') }}</span>
+            <v-btn x-small outlined @click="showChangeSpoolDialog = true">
+                {{ $t('Panels.SpoolmanPanel.ChangeSpool') }}
+            </v-btn>
+        </v-col>
+        <spoolman-change-spool-dialog v-model="showChangeSpoolDialog" :tool-index="toolIndex" />
+    </v-row>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Prop } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import { FileStateGcodefile } from '@/store/files/types'
+import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
+import { convertStringToArray } from '@/plugins/helpers'
+import { mdiAlert, mdiCheckCircle } from '@mdi/js'
+import SpoolmanChangeSpoolDialog from '@/components/dialogs/SpoolmanChangeSpoolDialog.vue'
+
+@Component({
+    components: { SpoolmanChangeSpoolDialog },
+})
+export default class StartPrintDialogSpoolmanTool extends Mixins(BaseMixin) {
+    mdiAlert = mdiAlert
+    mdiCheckCircle = mdiCheckCircle
+
+    @Prop({ required: true }) declare readonly file: FileStateGcodefile
+    @Prop({ required: true }) declare readonly toolIndex: number
+    @Prop({ required: false, default: false }) declare readonly borderTop: boolean
+
+    showChangeSpoolDialog = false
+
+    get toolName() {
+        return `T${this.toolIndex}`
+    }
+
+    get spoolId(): number | null {
+        return this.$store.state.server.spoolman.tool_spools?.[this.toolIndex] ?? null
+    }
+
+    get spoolDetail(): ServerSpoolmanStateSpool | null {
+        return this.$store.state.server.spoolman.tool_spool_details?.[this.toolIndex] ?? null
+    }
+
+    get fileFilamentType(): string {
+        const types = convertStringToArray(this.file.filament_type ?? '')
+        return types[this.toolIndex] ?? ''
+    }
+
+    get fileFilamentWeight(): number {
+        const weights = this.file.filament_weights ?? []
+        return weights[this.toolIndex] ?? 0
+    }
+
+    get warnings(): string[] {
+        const warnings: string[] = []
+
+        if (this.spoolId === null) {
+            warnings.push(this.$t('Panels.SpoolmanPanel.NoSpoolSelected') as string)
+            return warnings
+        }
+
+        // Check filament type mismatch
+        const fileType = this.fileFilamentType
+        const spoolType = this.spoolDetail?.filament?.material ?? ''
+        if (fileType !== '' && spoolType !== '' && fileType.toLowerCase() !== spoolType.toLowerCase()) {
+            warnings.push(
+                this.$t('Panels.SpoolmanPanel.FilamentTypeMismatch', {
+                    fileType,
+                    spoolType,
+                }) as string
+            )
+        }
+
+        // Check insufficient weight
+        const fileWeight = Math.round(this.fileFilamentWeight)
+        const spoolWeight = Math.round(this.spoolDetail?.remaining_weight ?? 0)
+        if (fileWeight > 0 && spoolWeight < fileWeight) {
+            warnings.push(
+                this.$t('Panels.SpoolmanPanel.TooLessFilament', {
+                    fileWeight,
+                    spoolWeight,
+                }) as string
+            )
+        }
+
+        return warnings
+    }
+}
+</script>
+
+<style scoped>
+._extruderColorState {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 1px solid lightgray;
+}
+</style>

--- a/src/components/dialogs/StartPrintDialogSpoolmanTool.vue
+++ b/src/components/dialogs/StartPrintDialogSpoolmanTool.vue
@@ -94,13 +94,13 @@ export default class StartPrintDialogSpoolmanTool extends Mixins(BaseMixin) {
             )
         }
 
-        // Check insufficient weight
-        const fileWeight = Math.round(this.fileFilamentWeight)
-        const spoolWeight = Math.round(this.spoolDetail?.remaining_weight ?? 0)
-        if (fileWeight > 0 && spoolWeight < fileWeight) {
+        // Check insufficient weight (only when spool details are loaded)
+        const fileWeight = this.fileFilamentWeight
+        if (this.spoolDetail && fileWeight > 0 && this.spoolDetail.remaining_weight < fileWeight) {
+            const spoolWeight = Math.round(this.spoolDetail.remaining_weight)
             warnings.push(
                 this.$t('Panels.SpoolmanPanel.TooLessFilament', {
-                    fileWeight,
+                    fileWeight: Math.round(fileWeight),
                     spoolWeight,
                 }) as string
             )

--- a/src/components/dialogs/StartPrintDialogSpoolmanTool.vue
+++ b/src/components/dialogs/StartPrintDialogSpoolmanTool.vue
@@ -5,7 +5,7 @@
                 <template #activator="{ on, attrs }">
                     <v-icon color="warning" v-bind="attrs" v-on="on">{{ mdiAlert }}</v-icon>
                 </template>
-                <span>{{ warnings.join('\n') }}</span>
+                <span style="white-space: pre-line">{{ warnings.join('\n') }}</span>
             </v-tooltip>
             <v-icon v-else color="success">{{ mdiCheckCircle }}</v-icon>
         </v-col>

--- a/src/components/panels/Spoolman/SpoolmanToolsDropdown.vue
+++ b/src/components/panels/Spoolman/SpoolmanToolsDropdown.vue
@@ -12,7 +12,7 @@
                     {{ $t('Panels.SpoolmanPanel.ActiveSpool') }}
                 </v-btn>
             </v-list-item>
-            <spoolman-tools-dropdown-item v-for="tool in tools" :key="tool" :object-name="tool" />
+            <spoolman-tools-dropdown-item v-for="tool in tools" :key="tool" :tool-index="tool" />
         </v-list>
         <spoolman-change-spool-dialog v-model="showChangeSpoolDialog" />
     </v-menu>
@@ -23,15 +23,16 @@ import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { mdiSwapVertical } from '@mdi/js'
 import SpoolmanToolsDropdownItem from '@/components/panels/Spoolman/SpoolmanToolsDropdownItem.vue'
+import SpoolmanChangeSpoolDialog from '@/components/dialogs/SpoolmanChangeSpoolDialog.vue'
 
 @Component({
-    components: { SpoolmanToolsDropdownItem },
+    components: { SpoolmanToolsDropdownItem, SpoolmanChangeSpoolDialog },
 })
 export default class SpoolmanToolsDropdown extends Mixins(BaseMixin) {
     mdiSwapVertical = mdiSwapVertical
 
     showChangeSpoolDialog = false
 
-    @Prop({ required: false, default: false }) readonly tools!: string[]
+    @Prop({ required: false, default: () => [] }) readonly tools!: number[]
 }
 </script>

--- a/src/components/panels/Spoolman/SpoolmanToolsDropdownItem.vue
+++ b/src/components/panels/Spoolman/SpoolmanToolsDropdownItem.vue
@@ -6,7 +6,10 @@
             <span v-if="spoolId === null" class="font-italic ml-1">({{ $t('Panels.SpoolmanPanel.NoSpool') }})</span>
             <span v-else class="ml-1">({{ spool?.filament?.name ?? '--' }})</span>
         </v-btn>
-        <spoolman-change-spool-dialog v-model="showChangeSpoolDialog" :tool="name" />
+        <v-btn v-if="spoolId !== null" icon x-small class="ml-1" :title="$t('Panels.SpoolmanPanel.EjectSpool')" @click="ejectSpool">
+            <v-icon small>{{ mdiEject }}</v-icon>
+        </v-btn>
+        <spoolman-change-spool-dialog v-model="showChangeSpoolDialog" :tool-index="toolIndex" />
     </v-list-item>
 </template>
 
@@ -14,17 +17,21 @@
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
+import SpoolmanChangeSpoolDialog from '@/components/dialogs/SpoolmanChangeSpoolDialog.vue'
+import { mdiEject } from '@mdi/js'
 
 @Component({
-    components: {},
+    components: { SpoolmanChangeSpoolDialog },
 })
 export default class SpoolmanToolsDropdownItem extends Mixins(BaseMixin) {
-    @Prop({ required: false, default: false }) readonly objectName!: string
+    mdiEject = mdiEject
+
+    @Prop({ required: true }) readonly toolIndex!: number
 
     showChangeSpoolDialog = false
 
     get name() {
-        return (this.objectName.split(' ')[1] ?? 'Unknown').toUpperCase()
+        return `T${this.toolIndex}`
     }
 
     get color() {
@@ -37,18 +44,38 @@ export default class SpoolmanToolsDropdownItem extends Mixins(BaseMixin) {
         }
     }
 
-    get spoolId() {
-        const object = this.$store.state.printer[this.objectName] ?? {}
+    get spoolId(): number | null {
+        // Prefer Moonraker API tool_spools
+        const toolSpools = this.$store.state.server.spoolman.tool_spools ?? {}
+        if (this.toolIndex in toolSpools) {
+            return toolSpools[this.toolIndex] ?? null
+        }
 
+        // Fall back to legacy gcode_macro detection
+        const macroName = `gcode_macro T${this.toolIndex}`
+        const object = this.$store.state.printer[macroName] ?? {}
         return object.spool_id ?? null
     }
 
-    get spool() {
+    get spool(): ServerSpoolmanStateSpool | null {
+        // Prefer tool_spool_details from Moonraker API
+        const detail = this.$store.state.server.spoolman.tool_spool_details?.[this.toolIndex] ?? null
+        if (detail) return detail
+
+        // Fall back to searching spools list
+        if (this.spoolId === null) return null
         return this.spools.find((spool) => spool.id === this.spoolId) ?? null
     }
 
     get spools(): ServerSpoolmanStateSpool[] {
         return this.$store.state.server.spoolman.spools ?? []
+    }
+
+    ejectSpool() {
+        this.$store.dispatch('server/spoolman/setToolSpool', {
+            tool: this.toolIndex,
+            spool_id: null,
+        })
     }
 }
 </script>

--- a/src/components/panels/Spoolman/SpoolmanToolsDropdownItem.vue
+++ b/src/components/panels/Spoolman/SpoolmanToolsDropdownItem.vue
@@ -72,10 +72,18 @@ export default class SpoolmanToolsDropdownItem extends Mixins(BaseMixin) {
     }
 
     ejectSpool() {
-        this.$store.dispatch('server/spoolman/setToolSpool', {
-            tool: this.toolIndex,
-            spool_id: null,
-        })
+        const toolSpools = this.$store.state.server.spoolman.tool_spools ?? {}
+        if (this.toolIndex in toolSpools) {
+            // Native Moonraker API path
+            this.$store.dispatch('server/spoolman/setToolSpool', {
+                tool: this.toolIndex,
+                spool_id: null,
+            })
+        } else {
+            // Legacy gcode_macro path
+            const macroName = `T${this.toolIndex}`
+            this.$store.dispatch('printer/sendGcode', `SET_GCODE_VARIABLE MACRO=${macroName} VARIABLE=spool_id VALUE=0`)
+        }
     }
 }
 </script>

--- a/src/components/panels/SpoolmanPanel.vue
+++ b/src/components/panels/SpoolmanPanel.vue
@@ -39,7 +39,7 @@
                         <v-list-item-title class="text-subtitle-2">
                             <strong>T{{ tool }}</strong>
                             <span v-if="getToolSpool(tool)" class="ml-2">
-                                {{ getToolSpool(tool).filament?.name ?? 'Unknown' }}
+                                {{ getToolSpool(tool).filament?.name ?? $t('Panels.SpoolmanPanel.UnknownFilament') }}
                             </span>
                             <span v-else class="ml-2 text--disabled font-italic">
                                 {{ $t('Panels.SpoolmanPanel.NoSpool') }}
@@ -47,7 +47,7 @@
                         </v-list-item-title>
                         <v-list-item-subtitle v-if="getToolSpool(tool)">
                             {{ getToolSpool(tool).filament?.material ?? '' }}
-                            | {{ Math.round(getToolSpool(tool).remaining_weight ?? 0) }}g remaining
+                            | {{ $t('Panels.SpoolmanPanel.RemainingWeight', { weight: Math.round(getToolSpool(tool).remaining_weight ?? 0) }) }}
                         </v-list-item-subtitle>
                     </v-list-item-content>
                 </v-list-item>

--- a/src/components/panels/SpoolmanPanel.vue
+++ b/src/components/panels/SpoolmanPanel.vue
@@ -1,7 +1,7 @@
 <template>
     <panel :icon="mdiAdjust" :title="title" card-class="spoolman-panel" :collapsible="true">
         <template #buttons>
-            <spoolman-tools-dropdown v-if="toolsWithSpoolId.length > 0" :tools="toolsWithSpoolId" />
+            <spoolman-tools-dropdown v-if="toolIndices.length > 0" :tools="toolIndices" />
             <v-btn v-else icon tile :title="changeSpoolTooltip" @click="showChangeSpoolDialog = true">
                 <v-icon>{{ mdiSwapVertical }}</v-icon>
             </v-btn>
@@ -12,12 +12,6 @@
                     </v-btn>
                 </template>
                 <v-list dense>
-                    <v-list-item>
-                        <v-btn small class="w-100" @click="showEjectSpoolDialog = true">
-                            <v-icon left>{{ mdiEject }}</v-icon>
-                            {{ $t('Panels.SpoolmanPanel.EjectSpool') }}
-                        </v-btn>
-                    </v-list-item>
                     <v-list-item v-if="spoolManagerUrl">
                         <v-btn small class="w-100" @click="openSpoolManager">
                             <v-icon left>{{ mdiOpenInNew }}</v-icon>
@@ -27,26 +21,47 @@
                 </v-list>
             </v-menu>
         </template>
-        <v-card-text v-if="active_spool === null">
-            <v-row>
-                <v-col class="text-center">
-                    <p class="text--disabled">{{ $t('Panels.SpoolmanPanel.NoActiveSpool') }}</p>
-                    <v-btn small color="primary" @click="showChangeSpoolDialog = true">
-                        {{ $t('Panels.SpoolmanPanel.SelectSpool') }}
-                    </v-btn>
-                </v-col>
-            </v-row>
-        </v-card-text>
-        <spoolman-panel-active-spool v-else @change-spool="showChangeSpoolDialog = true" />
+        <!-- Multi-tool: show all tool spools -->
+        <template v-if="toolIndices.length > 0">
+            <v-list dense class="py-0">
+                <v-list-item v-for="tool in toolIndices" :key="tool" class="px-4">
+                    <v-list-item-avatar :size="32" class="mr-3 my-1">
+                        <spool-icon v-if="getToolSpool(tool)" :color="'#' + (getToolSpool(tool).filament?.color_hex ?? '000000')" />
+                        <v-icon v-else color="grey lighten-1">{{ mdiAdjust }}</v-icon>
+                    </v-list-item-avatar>
+                    <v-list-item-content class="py-1">
+                        <v-list-item-title class="text-subtitle-2">
+                            <strong>T{{ tool }}</strong>
+                            <span v-if="getToolSpool(tool)" class="ml-2">
+                                {{ getToolSpool(tool).filament?.name ?? 'Unknown' }}
+                            </span>
+                            <span v-else class="ml-2 text--disabled font-italic">
+                                {{ $t('Panels.SpoolmanPanel.NoSpool') }}
+                            </span>
+                        </v-list-item-title>
+                        <v-list-item-subtitle v-if="getToolSpool(tool)">
+                            {{ getToolSpool(tool).filament?.material ?? '' }}
+                            | {{ Math.round(getToolSpool(tool).remaining_weight ?? 0) }}g remaining
+                        </v-list-item-subtitle>
+                    </v-list-item-content>
+                </v-list-item>
+            </v-list>
+        </template>
+        <!-- Single tool: legacy view -->
+        <template v-else>
+            <v-card-text v-if="active_spool === null">
+                <v-row>
+                    <v-col class="text-center">
+                        <p class="text--disabled">{{ $t('Panels.SpoolmanPanel.NoActiveSpool') }}</p>
+                        <v-btn small color="primary" @click="showChangeSpoolDialog = true">
+                            {{ $t('Panels.SpoolmanPanel.SelectSpool') }}
+                        </v-btn>
+                    </v-col>
+                </v-row>
+            </v-card-text>
+            <spoolman-panel-active-spool v-else @change-spool="showChangeSpoolDialog = true" />
+        </template>
         <spoolman-change-spool-dialog v-model="showChangeSpoolDialog" />
-        <confirmation-dialog
-            v-model="showEjectSpoolDialog"
-            :title="$t('Panels.SpoolmanPanel.EjectSpool')"
-            :text="$t('Panels.SpoolmanPanel.EjectSpoolQuestion')"
-            :action-button-text="$t('Panels.SpoolmanPanel.EjectSpool')"
-            action-button-color="primary"
-            :icon="mdiEject"
-            @action="ejectSpool" />
     </panel>
 </template>
 
@@ -56,12 +71,11 @@ import BaseMixin from '@/components/mixins/base'
 import Panel from '@/components/ui/Panel.vue'
 import { mdiAdjust, mdiDotsVertical, mdiEject, mdiOpenInNew, mdiSwapVertical } from '@mdi/js'
 import SpoolmanChangeSpoolDialog from '@/components/dialogs/SpoolmanChangeSpoolDialog.vue'
-import ConfirmationDialog from '@/components/dialogs/ConfirmationDialog.vue'
 import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
 import SpoolmanPanelActiveSpool from '@/components/panels/Spoolman/SpoolmanPanelActiveSpool.vue'
 
 @Component({
-    components: { ConfirmationDialog, SpoolmanPanelActiveSpool, Panel, SpoolmanChangeSpoolDialog },
+    components: { SpoolmanPanelActiveSpool, Panel, SpoolmanChangeSpoolDialog },
 })
 export default class SpoolmanPanel extends Mixins(BaseMixin) {
     mdiAdjust = mdiAdjust
@@ -71,7 +85,6 @@ export default class SpoolmanPanel extends Mixins(BaseMixin) {
     mdiSwapVertical = mdiSwapVertical
 
     showChangeSpoolDialog = false
-    showEjectSpoolDialog = false
 
     get health() {
         return this.$store.state.server.spoolman.health ?? ''
@@ -95,22 +108,49 @@ export default class SpoolmanPanel extends Mixins(BaseMixin) {
         return this.$store.state.server.spoolman.active_spool ?? null
     }
 
-    get toolsWithSpoolId() {
-        return Object.keys(this.$store.state.printer)
-            .filter((key) => /^gcode_macro T\d+$/i.test(key.toLowerCase()))
-            .filter((keys) => {
-                const object = this.$store.state.printer[keys] ?? {}
+    get toolIndices(): number[] {
+        const indices = new Set<number>()
 
-                return Object.keys(object).some((key) => key.toLowerCase() === 'spool_id')
+        // Add tools from Moonraker tool_spools map
+        const toolSpools = this.$store.state.server.spoolman.tool_spools ?? {}
+        for (const k of Object.keys(toolSpools)) {
+            indices.add(parseInt(k))
+        }
+
+        // Add tools from toolchanger if available
+        const toolchanger = this.$store.state.printer?.toolchanger ?? null
+        if (toolchanger?.tool_numbers?.length > 0) {
+            for (const n of toolchanger.tool_numbers) {
+                indices.add(n)
+            }
+        }
+
+        if (indices.size > 0) {
+            return [...indices].sort((a, b) => a - b)
+        }
+
+        // Fall back to legacy gcode_macro detection
+        const macroTools = Object.keys(this.$store.state.printer)
+            .filter((key) => /^gcode_macro T\d+$/i.test(key.toLowerCase()))
+            .filter((key) => {
+                const object = this.$store.state.printer[key] ?? {}
+                return Object.keys(object).some((k) => k.toLowerCase() === 'spool_id')
             })
+            .map((key) => {
+                const match = key.match(/T(\d+)/i)
+                return match ? parseInt(match[1]) : 0
+            })
+            .sort((a, b) => a - b)
+
+        return macroTools
+    }
+
+    getToolSpool(tool: number): ServerSpoolmanStateSpool | null {
+        return this.$store.state.server.spoolman.tool_spool_details?.[tool] ?? null
     }
 
     openSpoolManager() {
         window.open(this.spoolManagerUrl, '_blank')
-    }
-
-    ejectSpool() {
-        this.$store.dispatch('server/spoolman/setActiveSpool', null)
     }
 }
 </script>

--- a/src/components/panels/SpoolmanPanel.vue
+++ b/src/components/panels/SpoolmanPanel.vue
@@ -12,6 +12,12 @@
                     </v-btn>
                 </template>
                 <v-list dense>
+                    <v-list-item v-if="toolIndices.length === 0">
+                        <v-btn small class="w-100" @click="showEjectSpoolDialog = true">
+                            <v-icon left>{{ mdiEject }}</v-icon>
+                            {{ $t('Panels.SpoolmanPanel.EjectSpool') }}
+                        </v-btn>
+                    </v-list-item>
                     <v-list-item v-if="spoolManagerUrl">
                         <v-btn small class="w-100" @click="openSpoolManager">
                             <v-icon left>{{ mdiOpenInNew }}</v-icon>
@@ -62,6 +68,14 @@
             <spoolman-panel-active-spool v-else @change-spool="showChangeSpoolDialog = true" />
         </template>
         <spoolman-change-spool-dialog v-model="showChangeSpoolDialog" />
+        <confirmation-dialog
+            v-model="showEjectSpoolDialog"
+            :title="$t('Panels.SpoolmanPanel.EjectSpool')"
+            :text="$t('Panels.SpoolmanPanel.EjectSpoolQuestion')"
+            :action-button-text="$t('Panels.SpoolmanPanel.EjectSpool')"
+            action-button-color="primary"
+            :icon="mdiEject"
+            @action="ejectSpool" />
     </panel>
 </template>
 
@@ -71,11 +85,12 @@ import BaseMixin from '@/components/mixins/base'
 import Panel from '@/components/ui/Panel.vue'
 import { mdiAdjust, mdiDotsVertical, mdiEject, mdiOpenInNew, mdiSwapVertical } from '@mdi/js'
 import SpoolmanChangeSpoolDialog from '@/components/dialogs/SpoolmanChangeSpoolDialog.vue'
+import ConfirmationDialog from '@/components/dialogs/ConfirmationDialog.vue'
 import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
 import SpoolmanPanelActiveSpool from '@/components/panels/Spoolman/SpoolmanPanelActiveSpool.vue'
 
 @Component({
-    components: { SpoolmanPanelActiveSpool, Panel, SpoolmanChangeSpoolDialog },
+    components: { ConfirmationDialog, SpoolmanPanelActiveSpool, Panel, SpoolmanChangeSpoolDialog },
 })
 export default class SpoolmanPanel extends Mixins(BaseMixin) {
     mdiAdjust = mdiAdjust
@@ -85,6 +100,7 @@ export default class SpoolmanPanel extends Mixins(BaseMixin) {
     mdiSwapVertical = mdiSwapVertical
 
     showChangeSpoolDialog = false
+    showEjectSpoolDialog = false
 
     get health() {
         return this.$store.state.server.spoolman.health ?? ''
@@ -151,6 +167,10 @@ export default class SpoolmanPanel extends Mixins(BaseMixin) {
 
     openSpoolManager() {
         window.open(this.spoolManagerUrl, '_blank')
+    }
+
+    ejectSpool() {
+        this.$store.dispatch('server/spoolman/setActiveSpool', null)
     }
 }
 </script>

--- a/src/components/panels/SpoolmanPanel.vue
+++ b/src/components/panels/SpoolmanPanel.vue
@@ -88,9 +88,11 @@ import SpoolmanChangeSpoolDialog from '@/components/dialogs/SpoolmanChangeSpoolD
 import ConfirmationDialog from '@/components/dialogs/ConfirmationDialog.vue'
 import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
 import SpoolmanPanelActiveSpool from '@/components/panels/Spoolman/SpoolmanPanelActiveSpool.vue'
+import SpoolmanToolsDropdown from '@/components/panels/Spoolman/SpoolmanToolsDropdown.vue'
+import SpoolIcon from '@/components/ui/SpoolIcon.vue'
 
 @Component({
-    components: { ConfirmationDialog, SpoolmanPanelActiveSpool, Panel, SpoolmanChangeSpoolDialog },
+    components: { ConfirmationDialog, SpoolmanPanelActiveSpool, SpoolmanToolsDropdown, SpoolIcon, Panel, SpoolmanChangeSpoolDialog },
 })
 export default class SpoolmanPanel extends Mixins(BaseMixin) {
     mdiAdjust = mdiAdjust

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -961,6 +961,8 @@
             "NoActiveSpool": "Filament tracking is inactive. To get started, please select a spool.",
             "NoResults": "No spool found with the current search criteria.",
             "NoSpool": "No spool",
+            "RemainingWeight": "{weight}g remaining",
+            "UnknownFilament": "Unknown",
             "NoSpools": "No spools available",
             "NoSpoolSelected": "No spool selected. Please select a spool or this print will not be tracked.",
             "OpenSpoolManager": "open Spool Manager",

--- a/src/store/server/spoolman/actions.ts
+++ b/src/store/server/spoolman/actions.ts
@@ -50,6 +50,13 @@ export const actions: ActionTree<ServerSpoolmanState, RootState> = {
             { action: 'server/spoolman/getVendors' }
         )
 
+        // Fetch tool_spool_map from status endpoint
+        Vue.$socket.emit(
+            'server.spoolman.status',
+            {},
+            { action: 'server/spoolman/getToolSpoolMap' }
+        )
+
         dispatch('socket/addInitModule', 'server/spoolman/getActiveSpoolId', { root: true })
         dispatch('socket/addInitModule', 'server/spoolman/getHealth', { root: true })
         dispatch('socket/addInitModule', 'server/spoolman/getInfo', { root: true })
@@ -150,6 +157,91 @@ export const actions: ActionTree<ServerSpoolmanState, RootState> = {
         if (id !== null) params['spool_id'] = id
 
         Vue.$socket.emit('server.spoolman.post_spool_id', params)
+    },
+
+    setToolSpool(_, { tool, spool_id }: { tool: number; spool_id: number | null }) {
+        const params: { spool_id?: number; tool: number } = { tool }
+        if (spool_id !== null) params['spool_id'] = spool_id
+
+        Vue.$socket.emit('server.spoolman.post_spool_id', params)
+    },
+
+    getToolSpoolMap({ commit, dispatch }, payload) {
+        if ('requestParams' in payload) delete payload.requestParams
+        const toolSpoolMap = payload.tool_spool_map
+        if (!toolSpoolMap) return
+
+        const parsed: Record<number, number | null> = {}
+        for (const [key, value] of Object.entries(toolSpoolMap)) {
+            parsed[parseInt(key)] = value as number | null
+        }
+        commit('setToolSpools', parsed)
+
+        // Fetch spool details for each tool
+        for (const [tool, spoolId] of Object.entries(parsed)) {
+            if (spoolId === null) {
+                commit('setToolSpoolDetail', { tool: parseInt(tool), spool: null })
+                continue
+            }
+            dispatch('fetchToolSpoolDetail', { tool: parseInt(tool), spool_id: spoolId })
+        }
+    },
+
+    fetchToolSpoolDetail({ commit }, { tool, spool_id }: { tool: number; spool_id: number }) {
+        Vue.$socket.emit(
+            'server.spoolman.proxy',
+            {
+                request_method: 'GET',
+                use_v2_response: true,
+                path: `/v1/spool/${spool_id}`,
+            },
+            {
+                action: 'server/spoolman/getToolSpoolDetail',
+                actionPayload: { tool },
+            }
+        )
+    },
+
+    getToolSpoolDetail({ commit }, payload) {
+        const tool = payload.tool ?? null
+        if (tool === null) return
+        delete payload.tool
+        if ('requestParams' in payload) delete payload.requestParams
+
+        payload = convertV2response(payload)
+        commit('setToolSpoolDetail', { tool, spool: payload })
+    },
+
+    handleActiveSpoolSet({ commit, dispatch }, payload) {
+        // Handle notify_active_spool_set with tool field
+        const tool = payload.tool ?? 0
+        const spoolId = payload.spool_id ?? null
+
+        commit('setToolSpool', { tool, spool_id: spoolId })
+
+        if (spoolId !== null) {
+            dispatch('fetchToolSpoolDetail', { tool, spool_id: spoolId })
+        } else {
+            commit('setToolSpoolDetail', { tool, spool: null })
+        }
+
+        // Update legacy active_spool_id for tool 0
+        if (tool === 0) {
+            commit('setActiveSpoolId', spoolId)
+            if (spoolId !== null) {
+                Vue.$socket.emit(
+                    'server.spoolman.proxy',
+                    {
+                        request_method: 'GET',
+                        use_v2_response: true,
+                        path: `/v1/spool/${spoolId}`,
+                    },
+                    { action: 'server/spoolman/getActiveSpool' }
+                )
+            } else {
+                commit('setActiveSpool', null)
+            }
+        }
     },
 
     refreshActiveSpool({ state }) {

--- a/src/store/server/spoolman/actions.ts
+++ b/src/store/server/spoolman/actions.ts
@@ -210,8 +210,9 @@ export const actions: ActionTree<ServerSpoolmanState, RootState> = {
         delete payload.tool
         if ('requestParams' in payload) delete payload.requestParams
 
-        payload = convertV2response(payload)
-        commit('setToolSpoolDetail', { tool, spool: payload })
+        const spool = convertV2response(payload)
+        if (spool == null) return
+        commit('setToolSpoolDetail', { tool, spool })
     },
 
     handleActiveSpoolSet({ commit, dispatch }, payload) {

--- a/src/store/server/spoolman/actions.ts
+++ b/src/store/server/spoolman/actions.ts
@@ -173,7 +173,9 @@ export const actions: ActionTree<ServerSpoolmanState, RootState> = {
 
         const parsed: Record<number, number | null> = {}
         for (const [key, value] of Object.entries(toolSpoolMap)) {
-            parsed[parseInt(key)] = value as number | null
+            const tool = Number.parseInt(key, 10)
+            if (Number.isNaN(tool)) continue
+            parsed[tool] = value === 0 ? null : (value as number | null)
         }
         commit('setToolSpools', parsed)
 
@@ -215,7 +217,8 @@ export const actions: ActionTree<ServerSpoolmanState, RootState> = {
     handleActiveSpoolSet({ commit, dispatch }, payload) {
         // Handle notify_active_spool_set with tool field
         const tool = payload.tool ?? 0
-        const spoolId = payload.spool_id ?? null
+        const rawId = payload.spool_id ?? null
+        const spoolId = rawId === 0 ? null : rawId
 
         commit('setToolSpool', { tool, spool_id: spoolId })
 

--- a/src/store/server/spoolman/getters.ts
+++ b/src/store/server/spoolman/getters.ts
@@ -1,4 +1,12 @@
 import { GetterTree } from 'vuex'
 import { ServerSpoolmanState } from './types'
 
-export const getters: GetterTree<ServerSpoolmanState, any> = {}
+export const getters: GetterTree<ServerSpoolmanState, any> = {
+    getToolSpool: (state) => (tool: number) => {
+        return state.tool_spool_details[tool] ?? null
+    },
+
+    hasToolSpools: (state) => {
+        return Object.keys(state.tool_spools).length > 0
+    },
+}

--- a/src/store/server/spoolman/index.ts
+++ b/src/store/server/spoolman/index.ts
@@ -18,6 +18,8 @@ export const getDefaultState = (): ServerSpoolmanState => {
         active_spool: null,
         vendors: [],
         feeds: [],
+        tool_spools: {},
+        tool_spool_details: {},
     }
 }
 

--- a/src/store/server/spoolman/mutations.ts
+++ b/src/store/server/spoolman/mutations.ts
@@ -38,6 +38,11 @@ export const mutations: MutationTree<ServerSpoolmanState> = {
 
     setToolSpool(state, { tool, spool_id }: { tool: number; spool_id: number | null }) {
         Vue.set(state.tool_spools, tool, spool_id)
+        // Invalidate cached detail when spool changes or is ejected
+        const currentDetail = state.tool_spool_details[tool] ?? null
+        if (spool_id === null || currentDetail?.id !== spool_id) {
+            Vue.set(state.tool_spool_details, tool, null)
+        }
     },
 
     setToolSpoolDetail(state, { tool, spool }: { tool: number; spool: any }) {

--- a/src/store/server/spoolman/mutations.ts
+++ b/src/store/server/spoolman/mutations.ts
@@ -31,4 +31,16 @@ export const mutations: MutationTree<ServerSpoolmanState> = {
     setSpools(state, payload) {
         Vue.set(state, 'spools', payload)
     },
+
+    setToolSpools(state, payload: Record<number, number | null>) {
+        Vue.set(state, 'tool_spools', payload)
+    },
+
+    setToolSpool(state, { tool, spool_id }: { tool: number; spool_id: number | null }) {
+        Vue.set(state.tool_spools, tool, spool_id)
+    },
+
+    setToolSpoolDetail(state, { tool, spool }: { tool: number; spool: any }) {
+        Vue.set(state.tool_spool_details, tool, spool)
+    },
 }

--- a/src/store/server/spoolman/types.ts
+++ b/src/store/server/spoolman/types.ts
@@ -11,6 +11,8 @@ export interface ServerSpoolmanState {
     active_spool: ServerSpoolmanStateSpool | null
     vendors: ServerSpoolmanStateVendor[]
     feeds: string[]
+    tool_spools: Record<number, number | null>
+    tool_spool_details: Record<number, ServerSpoolmanStateSpool | null>
 }
 
 export interface ServerSpoolmanStateVendor {

--- a/src/store/socket/actions.ts
+++ b/src/store/socket/actions.ts
@@ -132,7 +132,7 @@ export const actions: ActionTree<SocketState, RootState> = {
                 break
 
             case 'notify_active_spool_set':
-                dispatch('server/spoolman/getActiveSpoolId', payload.params[0], { root: true })
+                dispatch('server/spoolman/handleActiveSpoolSet', payload.params[0], { root: true })
                 break
 
             case 'notify_sensor_update':

--- a/tests/store/server/spoolman/getters.spec.ts
+++ b/tests/store/server/spoolman/getters.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { getters } from '@/store/server/spoolman/getters'
+import { getDefaultState } from '@/store/server/spoolman/index'
+import type { ServerSpoolmanState, ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
+
+const makeSpool = (id: number, material = 'PLA'): ServerSpoolmanStateSpool => ({
+    id,
+    registered: '2026-01-01',
+    archived: false,
+    filament: {
+        id: 1,
+        registered: '2026-01-01',
+        name: `${material} Spool ${id}`,
+        color_hex: 'FF0000',
+        density: 1.24,
+        diameter: 1.75,
+        material,
+        price: 20,
+        settings_bed_temp: 60,
+        settings_extruder_temp: 210,
+        spool_weight: 200,
+        weight: 1000,
+        vendor: { id: 1, registered: '2026-01-01', name: 'TestVendor' },
+    },
+    first_used: '2026-01-01',
+    last_used: '2026-01-01',
+    remaining_length: 300,
+    remaining_weight: 800,
+    used_length: 100,
+    used_weight: 200,
+})
+
+// Helper to call a getter function with state.
+const callGetter = (name: string, state: ServerSpoolmanState) => {
+    const getter = getters[name]
+    if (typeof getter === 'function') {
+        return (getter as Function)(state, {}, {}, {})
+    }
+    return undefined
+}
+
+describe('spoolman getters', () => {
+    describe('getToolSpool', () => {
+        it('returns spool detail for a tool that has one', () => {
+            const state = getDefaultState()
+            const spool = makeSpool(5)
+            state.tool_spool_details = { 0: spool }
+            const fn = callGetter('getToolSpool', state)
+            expect(fn(0)).toEqual(spool)
+        })
+
+        it('returns null for a tool with no spool detail', () => {
+            const state = getDefaultState()
+            const fn = callGetter('getToolSpool', state)
+            expect(fn(0)).toBeNull()
+        })
+
+        it('returns correct spool for each tool in multi-tool setup', () => {
+            const state = getDefaultState()
+            const spool0 = makeSpool(10, 'PLA')
+            const spool1 = makeSpool(20, 'PETG')
+            state.tool_spool_details = { 0: spool0, 1: spool1 }
+            const fn = callGetter('getToolSpool', state)
+            expect(fn(0)?.id).toBe(10)
+            expect(fn(1)?.id).toBe(20)
+        })
+
+        it('returns null for unassigned tool in multi-tool setup', () => {
+            const state = getDefaultState()
+            state.tool_spool_details = { 0: makeSpool(10), 1: null }
+            const fn = callGetter('getToolSpool', state)
+            expect(fn(0)?.id).toBe(10)
+            expect(fn(1)).toBeNull()
+        })
+
+        it('returns null for out-of-range tool index', () => {
+            const state = getDefaultState()
+            state.tool_spool_details = { 0: makeSpool(10) }
+            const fn = callGetter('getToolSpool', state)
+            expect(fn(5)).toBeNull()
+        })
+    })
+
+    describe('hasToolSpools', () => {
+        it('returns false when tool_spools is empty (single-tool or no spoolman)', () => {
+            const state = getDefaultState()
+            const result = callGetter('hasToolSpools', state)
+            expect(result).toBe(false)
+        })
+
+        it('returns true when tool_spools has entries', () => {
+            const state = getDefaultState()
+            state.tool_spools = { 0: 100 }
+            const result = callGetter('hasToolSpools', state)
+            expect(result).toBe(true)
+        })
+
+        it('returns true when multi-tool map has entries (even null values)', () => {
+            const state = getDefaultState()
+            state.tool_spools = { 0: 100, 1: null }
+            const result = callGetter('hasToolSpools', state)
+            expect(result).toBe(true)
+        })
+    })
+})

--- a/tests/store/server/spoolman/mutations.spec.ts
+++ b/tests/store/server/spoolman/mutations.spec.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mutations } from '@/store/server/spoolman/mutations'
+import { getDefaultState } from '@/store/server/spoolman/index'
+import type { ServerSpoolmanState, ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
+
+// Vue.set is used in mutations; stub it to behave like a plain assignment.
+vi.mock('vue', () => ({
+    default: {
+        set: (obj: Record<string, any>, key: string | number, value: any) => {
+            obj[key] = value
+        },
+    },
+}))
+
+const makeSpool = (id: number, material = 'PLA'): ServerSpoolmanStateSpool => ({
+    id,
+    registered: '2026-01-01',
+    archived: false,
+    filament: {
+        id: 1,
+        registered: '2026-01-01',
+        name: `${material} Spool ${id}`,
+        color_hex: 'FF0000',
+        density: 1.24,
+        diameter: 1.75,
+        material,
+        price: 20,
+        settings_bed_temp: 60,
+        settings_extruder_temp: 210,
+        spool_weight: 200,
+        weight: 1000,
+        vendor: { id: 1, registered: '2026-01-01', name: 'TestVendor' },
+    },
+    first_used: '2026-01-01',
+    last_used: '2026-01-01',
+    remaining_length: 300,
+    remaining_weight: 800,
+    used_length: 100,
+    used_weight: 200,
+})
+
+describe('spoolman mutations', () => {
+    // -- reset --
+    describe('reset', () => {
+        it('resets state to defaults', () => {
+            const state: ServerSpoolmanState = {
+                ...getDefaultState(),
+                active_spool_id: 42,
+                tool_spools: { 0: 1, 1: 2 },
+                tool_spool_details: { 0: makeSpool(1), 1: makeSpool(2) },
+            }
+            mutations.reset(state)
+            expect(state.active_spool_id).toBeNull()
+            expect(state.tool_spools).toEqual({})
+            expect(state.tool_spool_details).toEqual({})
+        })
+    })
+
+    // -- single-tool (legacy) mutations --
+    describe('setActiveSpoolId', () => {
+        it('sets the active spool ID', () => {
+            const state = getDefaultState()
+            mutations.setActiveSpoolId(state, 5)
+            expect(state.active_spool_id).toBe(5)
+        })
+
+        it('sets null to clear the spool', () => {
+            const state = getDefaultState()
+            state.active_spool_id = 5
+            mutations.setActiveSpoolId(state, null)
+            expect(state.active_spool_id).toBeNull()
+        })
+    })
+
+    describe('setActiveSpool', () => {
+        it('sets the active spool object', () => {
+            const state = getDefaultState()
+            const spool = makeSpool(10)
+            mutations.setActiveSpool(state, spool)
+            expect(state.active_spool).toEqual(spool)
+        })
+
+        it('clears the active spool with null', () => {
+            const state = getDefaultState()
+            state.active_spool = makeSpool(10)
+            mutations.setActiveSpool(state, null)
+            expect(state.active_spool).toBeNull()
+        })
+    })
+
+    // -- multi-tool mutations --
+    describe('setToolSpools', () => {
+        it('sets the full tool-to-spool map', () => {
+            const state = getDefaultState()
+            const map = { 0: 100, 1: 200 }
+            mutations.setToolSpools(state, map)
+            expect(state.tool_spools).toEqual({ 0: 100, 1: 200 })
+        })
+
+        it('handles map with null values (unassigned tools)', () => {
+            const state = getDefaultState()
+            const map: Record<number, number | null> = { 0: 100, 1: null }
+            mutations.setToolSpools(state, map)
+            expect(state.tool_spools[0]).toBe(100)
+            expect(state.tool_spools[1]).toBeNull()
+        })
+
+        it('replaces existing map', () => {
+            const state = getDefaultState()
+            state.tool_spools = { 0: 1, 1: 2 }
+            mutations.setToolSpools(state, { 0: 99 })
+            expect(state.tool_spools).toEqual({ 0: 99 })
+        })
+    })
+
+    describe('setToolSpool', () => {
+        it('sets spool for a specific tool', () => {
+            const state = getDefaultState()
+            mutations.setToolSpool(state, { tool: 0, spool_id: 42 })
+            expect(state.tool_spools[0]).toBe(42)
+        })
+
+        it('sets spool for tool 1 independently of tool 0', () => {
+            const state = getDefaultState()
+            state.tool_spools = { 0: 10 }
+            mutations.setToolSpool(state, { tool: 1, spool_id: 20 })
+            expect(state.tool_spools[0]).toBe(10)
+            expect(state.tool_spools[1]).toBe(20)
+        })
+
+        it('clears spool with null (eject)', () => {
+            const state = getDefaultState()
+            state.tool_spools = { 0: 10, 1: 20 }
+            mutations.setToolSpool(state, { tool: 1, spool_id: null })
+            expect(state.tool_spools[0]).toBe(10)
+            expect(state.tool_spools[1]).toBeNull()
+        })
+    })
+
+    describe('setToolSpoolDetail', () => {
+        it('stores full spool detail for a tool', () => {
+            const state = getDefaultState()
+            const spool = makeSpool(5, 'PETG')
+            mutations.setToolSpoolDetail(state, { tool: 0, spool })
+            expect(state.tool_spool_details[0]).toEqual(spool)
+            expect(state.tool_spool_details[0]?.filament.material).toBe('PETG')
+        })
+
+        it('stores details for multiple tools', () => {
+            const state = getDefaultState()
+            const spool0 = makeSpool(5, 'PLA')
+            const spool1 = makeSpool(6, 'ABS')
+            mutations.setToolSpoolDetail(state, { tool: 0, spool: spool0 })
+            mutations.setToolSpoolDetail(state, { tool: 1, spool: spool1 })
+            expect(state.tool_spool_details[0]?.id).toBe(5)
+            expect(state.tool_spool_details[1]?.id).toBe(6)
+        })
+
+        it('clears detail with null', () => {
+            const state = getDefaultState()
+            state.tool_spool_details = { 0: makeSpool(5) }
+            mutations.setToolSpoolDetail(state, { tool: 0, spool: null })
+            expect(state.tool_spool_details[0]).toBeNull()
+        })
+    })
+})

--- a/tests/store/server/spoolman/mutations.spec.ts
+++ b/tests/store/server/spoolman/mutations.spec.ts
@@ -135,6 +135,31 @@ describe('spoolman mutations', () => {
             expect(state.tool_spools[0]).toBe(10)
             expect(state.tool_spools[1]).toBeNull()
         })
+
+        it('invalidates cached detail on eject', () => {
+            const state = getDefaultState()
+            state.tool_spools = { 0: 10 }
+            state.tool_spool_details = { 0: makeSpool(10) }
+            mutations.setToolSpool(state, { tool: 0, spool_id: null })
+            expect(state.tool_spool_details[0]).toBeNull()
+        })
+
+        it('invalidates cached detail when spool changes', () => {
+            const state = getDefaultState()
+            state.tool_spools = { 0: 10 }
+            state.tool_spool_details = { 0: makeSpool(10) }
+            mutations.setToolSpool(state, { tool: 0, spool_id: 20 })
+            expect(state.tool_spool_details[0]).toBeNull()
+        })
+
+        it('keeps cached detail when spool id is unchanged', () => {
+            const state = getDefaultState()
+            const spool = makeSpool(10)
+            state.tool_spools = { 0: 10 }
+            state.tool_spool_details = { 0: spool }
+            mutations.setToolSpool(state, { tool: 0, spool_id: 10 })
+            expect(state.tool_spool_details[0]).toEqual(spool)
+        })
     })
 
     describe('setToolSpoolDetail', () => {


### PR DESCRIPTION
## Description

This PR adds native per-tool Spoolman spool assignment using the Moonraker API, replacing the gcode_macro workaround for multi-tool printers (toolchangers, IDEX, MMU/AFC).

The Spoolman panel detects multi-tool setups via `tool_spool_map` from `server.spoolman.status` and shows per-tool spool selectors with color indicators. The start-print dialog validates each tool independently (filament type mismatch, insufficient weight). Single-tool printers are completely unaffected — the legacy path is preserved, and a fix restores the eject button that was accidentally dropped.

**Store changes:**
- `tool_spools` and `tool_spool_details` added to spoolman state
- `setToolSpool`, `getToolSpoolMap`, `handleActiveSpoolSet` actions using Moonraker's `server.spoolman.post_spool_id` with `tool` param
- `getToolSpool` getter and `setToolSpool`/`setToolSpoolDetail` mutations

**UI changes:**
- `SpoolmanPanel` detects tools from `tool_spool_map` keys, with fallback to toolchanger object and gcode_macro pattern
- `SpoolmanChangeSpoolDialog` accepts `toolIndex` prop for API-based assignment
- New `StartPrintDialogSpoolmanTool` component for per-tool pre-print validation
- Eject spool button restored for single-tool printers

**Tests:**
- 22 new unit tests covering mutations (`setToolSpools`, `setToolSpool`, `setToolSpoolDetail`, `reset`) and getters (`getToolSpool`, `hasToolSpools`) for single-tool, multi-tool, and eject scenarios

Requires companion Moonraker PR: Arksine/moonraker#1057

## Related Tickets & Documents

Fixes #2459
Related: #1732

## Mobile & Desktop Screenshots/Recordings

<img width="634" height="167" alt="image" src="https://github.com/user-attachments/assets/92cda602-2502-4a7a-8792-210ad51aba51" />
<img width="586" height="146" alt="image" src="https://github.com/user-attachments/assets/c8a616ab-aef4-424c-bec1-1b47686de176" />

## Are there any post-deployment tasks we need to perform?

Moonraker must be updated with per-tool spool tracking support (Arksine/moonraker#1057) for the new API to function. Without it, Mainsail falls back to the existing legacy gcode_macro path.
