### PR TITLE
fix(dialog): prevent duplicate bed_screws command sends

### DIFF
--- a/src/components/dialogs/TheBedScrewsDialog.vue
+++ b/src/components/dialogs/TheBedScrewsDialog.vue
@@ -8,7 +8,7 @@
             style="overflow: hidden"
             :height="isMobile ? 0 : 548">
             <template #buttons>
-                <v-btn icon tile @click="sendAbort">
+                <v-btn icon tile :disabled="isBusy" :loading="loadingAbort" @click="sendAbort">
                     <v-icon>{{ mdiCloseThick }}</v-icon>
                 </v-btn>
             </template>

--- a/src/components/dialogs/TheBedScrewsDialog.vue
+++ b/src/components/dialogs/TheBedScrewsDialog.vue
@@ -52,13 +52,13 @@
             </v-card-text>
             <v-card-actions>
                 <v-spacer></v-spacer>
-                <v-btn text :loading="loadingAbort" @click="sendAbort">
+                <v-btn text :loading="loadingAbort" :disabled="isBusy" @click="sendAbort">
                     {{ $t('BedScrews.Abort') }}
                 </v-btn>
-                <v-btn color="primary" text :loading="loadingAdjusted" @click="sendAdjusted">
+                <v-btn color="primary" text :loading="loadingAdjusted" :disabled="isBusy" @click="sendAdjusted">
                     {{ $t('BedScrews.Adjusted') }}
                 </v-btn>
-                <v-btn color="primary" text :loading="loadingAccept" @click="sendAccept">
+                <v-btn color="primary" text :loading="loadingAccept" :disabled="isBusy" @click="sendAccept">
                     {{ $t('BedScrews.Accept') }}
                 </v-btn>
             </v-card-actions>
@@ -122,6 +122,10 @@ export default class TheBedScrewsDialog extends Mixins(BaseMixin, ControlMixin) 
         return this.loadings.includes('bedScrewsAdjusted')
     }
 
+    get isBusy() {
+        return this.loadingAbort || this.loadingAccept || this.loadingAdjusted
+    }
+
     get screwNames() {
         const configKeys = Object.keys(this.config)
         const screwNameKeys = configKeys.filter((name: string) => name.startsWith('screw') && name.endsWith('_name'))
@@ -156,19 +160,19 @@ export default class TheBedScrewsDialog extends Mixins(BaseMixin, ControlMixin) 
     sendAbort() {
         const gcode = `ABORT`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
-        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'manualProbeAbort' })
+        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'bedScrewsAbort' })
     }
 
     sendAccept() {
         const gcode = `ACCEPT`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
-        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'manualProbeAccept' })
+        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'bedScrewsAccept' })
     }
 
     sendAdjusted() {
         const gcode = `ADJUSTED`
         this.$store.dispatch('server/addEvent', { message: gcode, type: 'command' })
-        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'manualProbeAccept' })
+        this.$socket.emit('printer.gcode.script', { script: gcode }, { loading: 'bedScrewsAdjusted' })
     }
 }
 </script>


### PR DESCRIPTION
*🐦‍⬛ Co-authored with Gravious.*

## Summary
- Fixes duplicate command sends from the Bed Screws dialog by wiring the correct loading keys.
- Disables all action buttons while a bed_screws command is in flight.

## Root Cause
`TheBedScrewsDialog` used `manualProbe*` loading keys when emitting `ABORT`, `ACCEPT`, and `ADJUSTED`, but the dialog's own loading/computed state checked `bedScrews*` keys.

This mismatch meant users could click actions multiple times before UI lockout, causing duplicate G-code dispatches and progression slips.

## Changes
- `sendAbort` now uses `loading: 'bedScrewsAbort'`
- `sendAccept` now uses `loading: 'bedScrewsAccept'`
- `sendAdjusted` now uses `loading: 'bedScrewsAdjusted'`
- Added `isBusy` computed property and applied `:disabled="isBusy"` to Abort/Adjusted/Accept buttons.

## Testing
- Verified loading key alignment in component.
- Verified button-disable behavior from component state wiring.
- Full test suite not run for this focused UI/state fix.
