### PR TITLE
fix(thumbnails): escapethumbnail URLs to prevent issues

### DIFF
--- a/src/components/dialogs/StartPrintDialogThumbnail.vue
+++ b/src/components/dialogs/StartPrintDialogThumbnail.vue
@@ -52,9 +52,8 @@ export default class StartPrintDialogThumbnail extends Mixins(BaseMixin) {
 
     get bigThumbnailUrl() {
         if (this.bigThumbnail === undefined || !('relative_path' in this.bigThumbnail)) return null
-
         const baseArray = [this.apiUrl, 'server/files/gcodes']
-        if (this.currentPathWithoutSlash) baseArray.push(this.currentPathWithoutSlash)
+        if (this.currentPathWithoutSlash) baseArray.push(escapePath(this.currentPathWithoutSlash))
         baseArray.push(escapePath(this.bigThumbnail.relative_path))
         const baseUrl = baseArray.join('/')
 

--- a/src/components/dialogs/StartPrintDialogThumbnail.vue
+++ b/src/components/dialogs/StartPrintDialogThumbnail.vue
@@ -13,6 +13,7 @@ import { Component, Mixins, Prop } from 'vue-property-decorator'
 import BaseMixin from '@/components/mixins/base'
 import { FileStateGcodefile } from '@/store/files/types'
 import { defaultBigThumbnailBackground, thumbnailBigMin } from '@/store/variables'
+import { escapePath } from '@/plugins/helpers'
 
 @Component
 export default class StartPrintDialogThumbnail extends Mixins(BaseMixin) {
@@ -54,7 +55,7 @@ export default class StartPrintDialogThumbnail extends Mixins(BaseMixin) {
 
         const baseArray = [this.apiUrl, 'server/files/gcodes']
         if (this.currentPathWithoutSlash) baseArray.push(this.currentPathWithoutSlash)
-        baseArray.push(this.bigThumbnail.relative_path)
+        baseArray.push(escapePath(this.bigThumbnail.relative_path))
         const baseUrl = baseArray.join('/')
 
         return `${baseUrl}?timestamp=${this.fileTimestamp}`

--- a/src/components/panels/Gcodefiles/GcodefilesThumbnail.vue
+++ b/src/components/panels/Gcodefiles/GcodefilesThumbnail.vue
@@ -105,7 +105,7 @@ export default class GcodefilesThumbnail extends Mixins(BaseMixin) {
 
             baseArray.push(subdirectory)
         }
-        baseArray.push(relativePath)
+        baseArray.push(escapePath(relativePath))
         const baseUrl = baseArray.join('/')
 
         return `${baseUrl}?timestamp=${this.fileTimestamp}`

--- a/src/store/farm/printer/getters.ts
+++ b/src/store/farm/printer/getters.ts
@@ -1,5 +1,5 @@
 import { defaultLogoColor, themeDir, thumbnailBigMin } from '@/store/variables'
-import { convertName } from '@/plugins/helpers'
+import { convertName, escapePath } from '@/plugins/helpers'
 import { GetterTree } from 'vuex'
 import { FarmPrinterState } from '@/store/farm/printer/types'
 import { GuiWebcamStateWebcam } from '@/store/gui/webcams/types'
@@ -141,8 +141,8 @@ export const getters: GetterTree<FarmPrinterState, RootState> = {
                     state.socket.port +
                     path +
                     '/server/files/gcodes/' +
-                    dir +
-                    thumbnail.relative_path
+                    escapePath(dir) +
+                    escapePath(thumbnail.relative_path)
                 )
         }
 


### PR DESCRIPTION
## Description

This PR adds escapePath (split urls on / and escape each part + join them) to all relative_path (the thumbnail metadata url) for gcode thumbnails.

## Related Tickets & Documents

fixes #2504 

## Mobile & Desktop Screenshots/Recordings

none

## [optional] Are there any post-deployment tasks we need to perform?

none
